### PR TITLE
Enable BorLogs by default on nodes

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -440,6 +440,7 @@ var (
 	BorLogsFlag = &cli.BoolFlag{
 		Name:  "bor.logs",
 		Usage: "Enable bor logs retrieval",
+		Value: true,
 	}
 
 	// Blob transaction pool settings

--- a/internal/cli/server/config.go
+++ b/internal/cli/server/config.go
@@ -682,7 +682,7 @@ func DefaultConfig() *Config {
 		GcMode:      "full",
 		StateScheme: "path",
 		Snapshot:    true,
-		BorLogs:     false,
+		BorLogs:     true,
 		TxPool: &TxPoolConfig{
 			Locals:       []string{},
 			NoLocals:     false,


### PR DESCRIPTION
# Description

The `BorLogs` flag controls whether we apply `eth_getLogs` filters to Bor contracts. When enabled, it ensures logs from StateSync transactions are included; when disabled, however, it can inadvertently omit certain ERC-20 transfers on these txs—such as the one detailed in [issue #1549](https://github.com/maticnetwork/bor/issues/1549).

So I believe it's better having this enabled by default and disabled by the users willing more performance.

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes
