### PR TITLE
eth/protocols: add nil check for tx before calling GetOptions

### DIFF
--- a/eth/protocols/eth/broadcast.go
+++ b/eth/protocols/eth/broadcast.go
@@ -158,7 +158,7 @@ func (p *Peer) announceTransactions() {
 				meta := p.txpool.GetMetadata(queue[count])
 				// BOR specific - DO NOT REMOVE
 				// Skip PIP-15 bundled transactions
-				if meta != nil && tx.GetOptions() == nil {
+				if tx != nil && meta != nil && tx.GetOptions() == nil {
 					pending = append(pending, queue[count])
 					pendingTypes = append(pendingTypes, meta.Type)
 					pendingSizes = append(pendingSizes, uint32(meta.Size))


### PR DESCRIPTION
# Description

Found issue:
```
Jul 23 16:20:22 polygon-mainnet bor.sh[1563]: panic: runtime error: invalid memory address or nil pointer dereference
Jul 23 16:20:22 polygon-mainnet bor.sh[1563]: [signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x1c3f99c]
Jul 23 16:20:22 polygon-mainnet bor.sh[1563]: goroutine 177336300 [running]:
Jul 23 16:20:22 polygon-mainnet bor.sh[1563]: github.com/ethereum/go-ethereum/core/types.(*Transaction).GetOptions(...)
Jul 23 16:20:22 polygon-mainnet bor.sh[1563]:         /bor/core/types/transaction.go:120
Jul 23 16:20:22 polygon-mainnet bor.sh[1563]: github.com/ethereum/go-ethereum/eth/protocols/eth.(*Peer).announceTransactions(0xc1565eb110)
Jul 23 16:20:22 polygon-mainnet bor.sh[1563]:         /bor/eth/protocols/eth/broadcast.go:161 +0x53c
Jul 23 16:20:22 polygon-mainnet bor.sh[1563]: created by github.com/ethereum/go-ethereum/eth/protocols/eth.NewPeer in goroutine 177336296
Jul 23 16:20:22 polygon-mainnet bor.sh[1563]:         /bor/eth/protocols/eth/peer.go:118 +0x50a
```

This change addresses a potential race condition during transaction announcement in `eth/protocols/eth/broadcast.go`. Specifically, it is possible that `p.txpool.Get(queue[count])` returns `nil` while `p.txpool.GetMetadata(queue[count])` returns a non-nil value. This can occur if a transaction is added to the txpool between these two calls.

Previously, the code only checked whether `meta` was non-nil before calling `tx.GetOptions()`. However, if `tx` is `nil`, invoking `GetOptions()` would cause a runtime panic.

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Checklist

- [ ] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [ ] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on amoy
- [ ] I have created new e2e tests into express-cli
