### PR TITLE
Stateless sync code cache fix

### DIFF
--- a/consensus/bor/bor.go
+++ b/consensus/bor/bor.go
@@ -111,8 +111,8 @@ var (
 	// be modified via out-of-range or non-contiguous headers.
 	errOutOfRangeChain = errors.New("out of range or non-contiguous chain")
 
-	errUncleDetected     = errors.New("uncles not allowed")
-	errUnknownValidators = errors.New("unknown validators")
+	errUncleDetected = errors.New("uncles not allowed")
+	// errUnknownValidators = errors.New("unknown validators")
 )
 
 // SignerFn is a signer callback function to request a header to be signed by a

--- a/consensus/bor/bor.go
+++ b/consensus/bor/bor.go
@@ -1298,7 +1298,7 @@ func (c *Bor) checkAndCommitSpan(
 	headerNumber := header.Number.Uint64()
 
 	tempState := state.Inner().Copy()
-	tempState.SetPrefetcher(nil)
+	tempState.ResetPrefetcher()
 	tempState.StartPrefetcher("bor", state.Witness())
 
 	span, err := c.spanner.GetCurrentSpan(ctx, header.ParentHash, tempState)
@@ -1443,7 +1443,7 @@ func (c *Bor) CommitStates(
 	if c.config.IsIndore(header.Number) {
 		// Fetch the LastStateId from contract via current state instance
 		tempState := state.Inner().Copy()
-		tempState.SetPrefetcher(nil)
+		tempState.ResetPrefetcher()
 		tempState.StartPrefetcher("bor", state.Witness())
 
 		lastStateIDBig, err = c.GenesisContractsClient.LastStateId(tempState, number-1, header.ParentHash)

--- a/consensus/bor/snapshot.go
+++ b/consensus/bor/snapshot.go
@@ -179,33 +179,6 @@ func (s *Snapshot) apply(headers []*types.Header, c *Bor) (*Snapshot, error) {
 	return snap, nil
 }
 
-func (s *Snapshot) applyNumber(number uint64, c *Bor) (*Snapshot, error) {
-	if s.Number != number-1 {
-		return nil, errOutOfRangeChain
-	}
-
-	snap := s.copy()
-
-	span, err := c.spanStore.spanByBlockNumber(context.Background(), number)
-	if err != nil {
-		return nil, err
-	}
-	producers := make([]*valset.Validator, len(span.SelectedProducers))
-	for i, validator := range span.SelectedProducers {
-		producers[i] = &valset.Validator{
-			Address:     common.HexToAddress(validator.Signer),
-			VotingPower: validator.VotingPower,
-		}
-	}
-	v := getUpdatedValidatorSet(snap.ValidatorSet.Copy(), producers)
-
-	v.IncrementProposerPriority(1)
-
-	snap.ValidatorSet = v
-
-	return snap, nil
-}
-
 // GetSignerSuccessionNumber returns the relative position of signer in terms of the in-turn proposer
 func (s *Snapshot) GetSignerSuccessionNumber(signer common.Address) (int, error) {
 	validators := s.ValidatorSet.Validators

--- a/consensus/bor/span_store.go
+++ b/consensus/bor/span_store.go
@@ -19,7 +19,7 @@ import (
 // maxSpanFetchLimit denotes maximum number of future spans to fetch. During snap sync,
 // we verify very large batch of headers. The maximum range is not known as of now and
 // hence we set a very high limit. It can be reduced later.
-const maxSpanFetchLimit = 10_000
+// const maxSpanFetchLimit = 10_000
 
 // SpanStore acts as a simple middleware to cache span data populated from heimdall. It is used
 // in multiple places of bor consensus for verification.
@@ -272,7 +272,6 @@ func (s *SpanStore) estimateSpanId(blockNumber uint64) uint64 {
 				if lastUsedSpan.Id >= spansToDecrement { // Prevent underflow for uint64
 					return lastUsedSpan.Id - spansToDecrement
 				} else {
-
 					return 1 + (blockNumber-zerothSpanEnd-1)/defaultSpanLength
 				}
 			} else {

--- a/consensus/bor/span_store_test.go
+++ b/consensus/bor/span_store_test.go
@@ -82,7 +82,7 @@ func (h *MockHeimdallClient) GetLatestSpan(ctx context.Context) (*types.Span, er
 func TestSpanStore_SpanById(t *testing.T) {
 	spanStore := NewSpanStore(&MockHeimdallClient{}, nil, "1337")
 	defer spanStore.Close()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	type Testcase struct {
 		id         uint64
@@ -136,7 +136,7 @@ func TestSpanStore_SpanById(t *testing.T) {
 func TestSpanStore_SpanByBlockNumber(t *testing.T) {
 	spanStore := NewSpanStore(&MockHeimdallClient{}, nil, "1337")
 	defer spanStore.Close()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	type Testcase struct {
 		blockNumber uint64
@@ -391,7 +391,7 @@ func (h *MockOverlappingHeimdallClient) Close() {
 func TestSpanStore_SpanByBlockNumber_OverlappingSpans(t *testing.T) {
 	spanStore := NewSpanStore(&MockOverlappingHeimdallClient{}, nil, "1337")
 	defer spanStore.Close()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Pre-load spans 0-4 into cache to simulate known spans
 	for i := uint64(0); i <= 4; i++ {
@@ -470,7 +470,7 @@ func TestSpanStore_SpanByBlockNumber_OverlappingSpans(t *testing.T) {
 func TestSpanStore_SpanByBlockNumber_OverlappingSpansWithFuture(t *testing.T) {
 	spanStore := NewSpanStore(&MockOverlappingHeimdallClient{}, nil, "1337")
 	defer spanStore.Close()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Pre-load spans 0-2 into cache, leaving spans 3-6 as "future" spans
 	for i := uint64(0); i <= 2; i++ {
@@ -494,7 +494,7 @@ func TestSpanStore_SpanByBlockNumber_OverlappingSpansWithFuture(t *testing.T) {
 func TestSpanStore_SpanByBlockNumber_OverlappingSpansMultipleMatches(t *testing.T) {
 	spanStore := NewSpanStore(&MockOverlappingHeimdallClient{}, nil, "1337")
 	defer spanStore.Close()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Pre-load all spans 0-6 into cache
 	for i := uint64(0); i <= 6; i++ {
@@ -520,7 +520,7 @@ func TestSpanStore_SpanByBlockNumber_OverlappingSpansMultipleMatches(t *testing.
 }
 
 func TestSpanStore_GetFutureSpan(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	type testCase struct {
 		name              string
@@ -662,7 +662,7 @@ func TestSpanStore_GetFutureSpan(t *testing.T) {
 
 			// Pre-load some spans to make the store behave more realistically
 			for i := uint64(0); i <= tc.latestKnownSpanID; i++ {
-				_, err := spanStore.spanById(context.Background(), i)
+				_, err := spanStore.spanById(t.Context(), i)
 				require.NoError(t, err)
 			}
 
@@ -799,7 +799,7 @@ func TestSpanStore_EstimateSpanId(t *testing.T) {
 }
 
 func TestGetMockSpan0(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	chainId := "1337"
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1981,11 +1981,7 @@ func (bc *BlockChain) writeBlockWithState(block *types.Block, receipts []*types.
 		}
 	}
 
-	batch := bc.db.NewBatch()
-	rawdb.WriteBytecodeSyncLastBlock(batch, block.NumberU64())
-	if err := batch.Write(); err != nil {
-		log.Crit("Failed to write bytecode sync last block into disk", "err", err)
-	}
+	rawdb.WriteBytecodeSyncLastBlock(bc.db, block.NumberU64())
 
 	// If node is running in path mode, skip explicit gc operation
 	// which is unnecessary in this mode.

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1986,6 +1986,13 @@ func (bc *BlockChain) writeBlockWithState(block *types.Block, receipts []*types.
 			return []*types.Log{}, err
 		}
 	}
+
+	batch := bc.db.NewBatch()
+	rawdb.WriteBytecodeSyncLastBlock(batch, block.NumberU64())
+	if err := batch.Write(); err != nil {
+		log.Crit("Failed to write bytecode sync last block into disk", "err", err)
+	}
+
 	// If node is running in path mode, skip explicit gc operation
 	// which is unnecessary in this mode.
 	if bc.triedb.Scheme() == rawdb.PathScheme {

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -110,12 +110,12 @@ var (
 	blockPrefetchExecuteTimer   = metrics.NewRegisteredTimer("chain/prefetch/executes", nil)
 	blockPrefetchInterruptMeter = metrics.NewRegisteredMeter("chain/prefetch/interrupts", nil)
 
-	errInsertionInterrupted     = errors.New("insertion is interrupted")
-	errChainStopped             = errors.New("blockchain is stopped")
-	errInvalidOldChain          = errors.New("invalid old chain")
-	errInvalidNewChain          = errors.New("invalid new chain")
-	errWitnessTimeout           = errors.New("timeout waiting for witness computation")     // New error
-	errWitnessComputationFailed = errors.New("witness computation failed or was cancelled") // New error
+	errInsertionInterrupted = errors.New("insertion is interrupted")
+	errChainStopped         = errors.New("blockchain is stopped")
+	errInvalidOldChain      = errors.New("invalid old chain")
+	errInvalidNewChain      = errors.New("invalid new chain")
+	// errWitnessTimeout           = errors.New("timeout waiting for witness computation")     // New error
+	// errWitnessComputationFailed = errors.New("witness computation failed or was cancelled") // New error
 )
 
 const (
@@ -233,12 +233,6 @@ var DefaultCacheConfig = defaultCacheConfig
 type txLookup struct {
 	lookup      *rawdb.LegacyTxLookupEntry
 	transaction *types.Transaction
-}
-
-// witnessResult holds the outcome of a witness computation.
-type witnessResult struct {
-	witness *stateless.Witness
-	err     error
 }
 
 // BlockChain represents the canonical chain given a database with a genesis

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -4695,10 +4695,9 @@ func TestPragueRequests(t *testing.T) {
 
 // mockChainValidator is a mock implementation of ethereum.ChainValidator for testing
 type mockChainValidator struct {
-	hasMilestone     bool
-	milestoneNumber  uint64
-	milestoneHash    common.Hash
-	shouldFailHeader map[uint64]bool // block numbers that should fail verification
+	hasMilestone    bool
+	milestoneNumber uint64
+	milestoneHash   common.Hash
 }
 
 func (m *mockChainValidator) IsValidPeer(fetchHeadersByNumber func(number uint64, amount int, skip int, reverse bool) ([]*types.Header, []common.Hash, error)) (bool, error) {

--- a/core/rawdb/accessors_state.go
+++ b/core/rawdb/accessors_state.go
@@ -309,7 +309,6 @@ func DeleteWitness(db ethdb.KeyValueWriter, blockHash common.Hash) {
 	if err := db.Delete(witnessSizeKey(blockHash)); err != nil {
 		log.Crit("Failed to remove witness size", "err", err)
 	}
-
 }
 
 func ReadWitnessPruneCursor(db ethdb.KeyValueReader) *uint64 {

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -737,7 +737,7 @@ var knownMetadataKeys = [][]byte{
 	snapshotGeneratorKey, snapshotRecoveryKey, txIndexTailKey, fastTxLookupLimitKey,
 	uncleanShutdownKey, badBlockKey, transitionStatusKey, skeletonSyncStatusKey,
 	persistentStateIDKey, trieJournalKey, snapshotSyncStatusKey, snapSyncStatusFlagKey,
-	filterMapsRangeKey,
+	filterMapsRangeKey, bytecodeSyncLastBlockKey,
 }
 
 // printChainMetadata prints out chain metadata to stderr.

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -531,9 +531,11 @@ func (s *stateObject) Code() []byte {
 	}
 	code, err := s.db.reader.Code(s.address, common.BytesToHash(s.CodeHash()))
 	if err != nil {
+		log.Error("Failed to load code", "address", s.address, "hash", fmt.Sprintf("%x", s.CodeHash()), "err", err)
 		s.db.setError(fmt.Errorf("can't load code hash %x: %v", s.CodeHash(), err))
 	}
 	if len(code) == 0 {
+		log.Error("Code is not found", "address", s.address, "hash", fmt.Sprintf("%x", s.CodeHash()))
 		s.db.setError(fmt.Errorf("code is not found %x", s.CodeHash()))
 	}
 	s.code = code

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -525,8 +525,11 @@ func (s *StateDB) StopPrefetcher() {
 	}
 }
 
-func (s *StateDB) SetPrefetcher(prefetcher *triePrefetcher) {
-	s.prefetcher = prefetcher
+// ResetPrefetcher cleans the prefetcher from a State, commonly used in tempStates to track witness while no impacting block building
+// Do also remove mutations previously tracked to just look to the new ones
+func (s *StateDB) ResetPrefetcher() {
+	s.prefetcher = nil
+	s.mutations = make(map[common.Address]*mutation)
 }
 
 // setError remembers the first non-nil error it is called with.

--- a/core/state/sync.go
+++ b/core/state/sync.go
@@ -25,7 +25,7 @@ import (
 )
 
 // NewStateSync creates a new state trie download scheduler.
-func NewStateSync(root common.Hash, database ethdb.KeyValueReader, onLeaf func(keys [][]byte, leaf []byte) error, scheme string) *trie.Sync {
+func NewStateSync(root common.Hash, database ethdb.KeyValueReader, onLeaf func(keys [][]byte, leaf []byte) error, scheme string, bytecodeOnlyMode bool) *trie.Sync {
 	// Register the storage slot callback if the external callback is specified.
 	var onSlot func(keys [][]byte, path []byte, leaf []byte, parent common.Hash, parentPath []byte) error
 	if onLeaf != nil {
@@ -55,7 +55,7 @@ func NewStateSync(root common.Hash, database ethdb.KeyValueReader, onLeaf func(k
 
 		return nil
 	}
-	syncer = trie.NewSync(root, database, onAccount, scheme)
+	syncer = trie.NewSync(root, database, onAccount, scheme, bytecodeOnlyMode)
 
 	return syncer
 }

--- a/core/state/sync_test.go
+++ b/core/state/sync_test.go
@@ -140,11 +140,11 @@ func TestEmptyStateSync(t *testing.T) {
 	dbA := triedb.NewDatabase(rawdb.NewMemoryDatabase(), nil)
 	dbB := triedb.NewDatabase(rawdb.NewMemoryDatabase(), &triedb.Config{PathDB: pathdb.Defaults})
 
-	sync := NewStateSync(types.EmptyRootHash, rawdb.NewMemoryDatabase(), nil, dbA.Scheme())
+	sync := NewStateSync(types.EmptyRootHash, rawdb.NewMemoryDatabase(), nil, dbA.Scheme(), false)
 	if paths, nodes, codes := sync.Missing(1); len(paths) != 0 || len(nodes) != 0 || len(codes) != 0 {
 		t.Errorf("content requested for empty state: %v, %v, %v", nodes, paths, codes)
 	}
-	sync = NewStateSync(types.EmptyRootHash, rawdb.NewMemoryDatabase(), nil, dbB.Scheme())
+	sync = NewStateSync(types.EmptyRootHash, rawdb.NewMemoryDatabase(), nil, dbB.Scheme(), false)
 	if paths, nodes, codes := sync.Missing(1); len(paths) != 0 || len(nodes) != 0 || len(codes) != 0 {
 		t.Errorf("content requested for empty state: %v, %v, %v", nodes, paths, codes)
 	}
@@ -195,7 +195,7 @@ func testIterativeStateSync(t *testing.T, count int, commit bool, bypath bool, s
 
 	// Create a destination state and sync with the scheduler
 	dstDb := rawdb.NewMemoryDatabase()
-	sched := NewStateSync(srcRoot, dstDb, nil, ndb.Scheme())
+	sched := NewStateSync(srcRoot, dstDb, nil, ndb.Scheme(), false)
 
 	var (
 		nodeElements []stateElement
@@ -338,7 +338,7 @@ func testIterativeDelayedStateSync(t *testing.T, scheme string) {
 
 	// Create a destination state and sync with the scheduler
 	dstDb := rawdb.NewMemoryDatabase()
-	sched := NewStateSync(srcRoot, dstDb, nil, ndb.Scheme())
+	sched := NewStateSync(srcRoot, dstDb, nil, ndb.Scheme(), false)
 
 	var (
 		nodeElements []stateElement
@@ -466,7 +466,7 @@ func testIterativeRandomStateSync(t *testing.T, count int, scheme string) {
 
 	// Create a destination state and sync with the scheduler
 	dstDb := rawdb.NewMemoryDatabase()
-	sched := NewStateSync(srcRoot, dstDb, nil, ndb.Scheme())
+	sched := NewStateSync(srcRoot, dstDb, nil, ndb.Scheme(), false)
 
 	nodeQueue := make(map[string]stateElement)
 	codeQueue := make(map[common.Hash]struct{})
@@ -575,7 +575,7 @@ func testIterativeRandomDelayedStateSync(t *testing.T, scheme string) {
 
 	// Create a destination state and sync with the scheduler
 	dstDb := rawdb.NewMemoryDatabase()
-	sched := NewStateSync(srcRoot, dstDb, nil, ndb.Scheme())
+	sched := NewStateSync(srcRoot, dstDb, nil, ndb.Scheme(), false)
 
 	nodeQueue := make(map[string]stateElement)
 	codeQueue := make(map[common.Hash]struct{})
@@ -705,7 +705,7 @@ func testIncompleteStateSync(t *testing.T, scheme string) {
 
 	// Create a destination state and sync with the scheduler
 	dstDb := rawdb.NewMemoryDatabase()
-	sched := NewStateSync(srcRoot, dstDb, nil, ndb.Scheme())
+	sched := NewStateSync(srcRoot, dstDb, nil, ndb.Scheme(), false)
 
 	var (
 		addedCodes  []common.Hash

--- a/core/stateless/encoding.go
+++ b/core/stateless/encoding.go
@@ -46,8 +46,8 @@ var (
 	decompressionTimer = metrics.NewRegisteredTimer("witness/decompression/timer", nil)
 
 	// Meters for rates
-	compressionRate   = metrics.NewRegisteredMeter("witness/compression/rate", nil)
-	decompressionRate = metrics.NewRegisteredMeter("witness/decompression/rate", nil)
+	// compressionRate   = metrics.NewRegisteredMeter("witness/compression/rate", nil)
+	// decompressionRate = metrics.NewRegisteredMeter("witness/decompression/rate", nil)
 )
 
 // CompressionStats returns current compression statistics

--- a/eth/downloader/bor_downloader.go
+++ b/eth/downloader/bor_downloader.go
@@ -1129,6 +1129,11 @@ func (d *Downloader) findAncestor(p *peerConnection, remoteHeader *types.Header)
 // without skipping any blocks. This is necessary for stateless nodes which may have gaps
 // in their locally stored blocks.
 func (d *Downloader) findAncestorStatelessSearch(p *peerConnection, remoteHeight uint64, floor int64) (uint64, error) {
+	// If the remote height is 0, we are at the genesis block, so we can return 0
+	if remoteHeight == 0 {
+		return 0, nil
+	}
+
 	currentHeight := int64(remoteHeight)
 
 	// Keep fetching headers backwards until we find an ancestor or reach the floor

--- a/eth/downloader/bor_downloader.go
+++ b/eth/downloader/bor_downloader.go
@@ -1181,7 +1181,7 @@ func (d *Downloader) findAncestorStatelessSearch(p *peerConnection, remoteHeight
 			h := hashes[i]
 			n := headers[i].Number.Uint64()
 
-			if d.blockchain.HasBlock(h, n) {
+			if d.blockchain.HasHeader(h, n) {
 				p.log.Debug("Found common ancestor", "number", n, "hash", h)
 				return n, nil
 			}

--- a/eth/downloader/bor_downloader_test.go
+++ b/eth/downloader/bor_downloader_test.go
@@ -1770,7 +1770,7 @@ func TestSpawnSyncDominant(t *testing.T) {
 		)
 
 		// Use a custom cancel channel to track cancellation
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(t.Context())
 		defer cancel()
 
 		// Regular fetcher that waits for cancellation
@@ -1897,7 +1897,7 @@ func TestSpawnSyncDominant(t *testing.T) {
 		)
 
 		// Use a custom context for cancellation tracking
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(t.Context())
 		defer cancel()
 
 		// Create multiple regular fetchers

--- a/eth/downloader/queue.go
+++ b/eth/downloader/queue.go
@@ -201,6 +201,9 @@ func newQueue(blockCacheLimit int, thresholdInitialSize int) *queue {
 		thresholdInitialSize: thresholdInitialSize,
 	}
 
+	// Initialize the queue by calling Reset
+	q.Reset(blockCacheLimit, thresholdInitialSize)
+
 	return q
 }
 

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -77,8 +77,8 @@ var Defaults = Config{
 	RPCEVMTimeout:         5 * time.Second,
 	GPO:                   FullNodeGPO,
 	RPCTxFeeCap:           1, // 1 ether
-	FastForwardThreshold:  100,
-	WitnessPruneThreshold: 6400,
+	FastForwardThreshold:  6400,
+	WitnessPruneThreshold: 64000,
 	WitnessPruneInterval:  120,
 }
 

--- a/eth/fetcher/block_fetcher_race_test.go
+++ b/eth/fetcher/block_fetcher_race_test.go
@@ -64,7 +64,7 @@ func TestBlockFetcherConcurrentMapAccess(t *testing.T) {
 	const numOperationsPerGoroutine = 20
 
 	var wg sync.WaitGroup
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 
 	// Create test blocks
@@ -259,7 +259,7 @@ func TestWitnessManagerConcurrentAccess(t *testing.T) {
 	const numOperationsPerGoroutine = 15
 
 	var wg sync.WaitGroup
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 
 	// Create test blocks

--- a/eth/fetcher/block_fetcher_test.go
+++ b/eth/fetcher/block_fetcher_test.go
@@ -1039,23 +1039,6 @@ func (f *fetcherTester) makeWitnessFetcher(peer string, blocks map[common.Hash]*
 	}
 }
 
-// verifyWitnessingEvent verifies that a witness request arrives within a timeout.
-func verifyWitnessingEvent(t *testing.T, witnessing chan *wit.Request, arrive bool) {
-	if arrive {
-		select {
-		case <-witnessing:
-		case <-time.After(time.Second):
-			t.Fatalf("witness request timeout")
-		}
-	} else {
-		select {
-		case <-witnessing:
-			t.Fatalf("unexpected witness request")
-		case <-time.After(100 * time.Millisecond):
-		}
-	}
-}
-
 // TestFullWitnessFetching tests witness fetching in full mode.
 func TestFullWitnessFetching(t *testing.T) {
 	testWitnessFetching(t, false)

--- a/eth/fetcher/witness_manager_test.go
+++ b/eth/fetcher/witness_manager_test.go
@@ -24,18 +24,6 @@ func createTestBlock(number uint64) *types.Block {
 	return types.NewBlock(header, nil, nil, trie.NewStackTrie(nil))
 }
 
-func createTestWitness() *stateless.Witness {
-	// Create a witness with a valid header using the proper constructor
-	header := &types.Header{
-		Number: big.NewInt(101),
-	}
-	witness, err := stateless.NewWitness(header, nil)
-	if err != nil {
-		panic(err) // This shouldn't happen in tests
-	}
-	return witness
-}
-
 func createTestWitnessForBlock(block *types.Block) *stateless.Witness {
 	// Create a witness with the same header as the block
 	witness, err := stateless.NewWitness(block.Header(), nil)

--- a/eth/handler_eth.go
+++ b/eth/handler_eth.go
@@ -169,7 +169,6 @@ func (h *ethHandler) handleBlockBroadcast(peer *eth.Peer, block *types.Block, td
 			// Return nil? Or the error? Let's return nil as dropping isn't a peer protocol error.
 			return nil
 		}
-
 	} else {
 		// Not in stateless mode, use the direct Enqueue optimization.
 		h.blockFetcher.Enqueue(peer.ID(), block)

--- a/eth/peer_test.go
+++ b/eth/peer_test.go
@@ -127,7 +127,6 @@ func TestRequestWitnesses_Controlling_Max_Concurrent_Calls(t *testing.T) {
 				}
 
 				if !shouldFail {
-
 					ch <- &wit.Response{
 						Res: &wit.WitnessPacketRLPPacket{
 							WitnessPacketResponse: []wit.WitnessPageResponse{{Page: wpr[0].Page, TotalPages: uint64(totalPages), Hash: hashToRequest, Data: witBuf.Bytes()[start:end]}},
@@ -139,7 +138,6 @@ func TestRequestWitnesses_Controlling_Max_Concurrent_Calls(t *testing.T) {
 						Res:  0,
 						Done: make(chan error, 10), // buffered so no block
 					}
-
 				}
 
 				muConcurrentCount.Lock()

--- a/eth/peerset.go
+++ b/eth/peerset.go
@@ -378,14 +378,6 @@ func (ps *peerSet) snapLen() int {
 	return ps.snapPeers
 }
 
-// witLen returns if the current number of `wit` peers in the set.
-func (ps *peerSet) witLen() int {
-	ps.lock.RLock()
-	defer ps.lock.RUnlock()
-
-	return ps.witPeers
-}
-
 // peerWithHighestTD retrieves the known peer with the currently highest total
 // difficulty, but below the given PoS switchover threshold.
 func (ps *peerSet) peerWithHighestTD() *eth.Peer {

--- a/eth/protocols/snap/sync.go
+++ b/eth/protocols/snap/sync.go
@@ -637,16 +637,6 @@ func (s *Syncer) Sync(root common.Hash, cancel chan struct{}) error {
 	// Retrieve the previous sync status from LevelDB and abort if already synced
 	s.loadSyncStatus()
 
-	// In bytecode-only mode, we always need to do a fresh scan for new contracts
-	// if s.bytecodeOnlyMode {
-	// 	// Clear any existing tasks and force a fresh scan
-	// 	s.lock.Lock()
-	// 	s.tasks = nil
-	// 	s.snapped = false
-	// 	s.lock.Unlock()
-	// 	// Create fresh tasks for scanning
-	// 	s.loadSyncStatus()
-	// } else
 	if len(s.tasks) == 0 && s.healer.scheduler.Pending() == 0 {
 		log.Debug("Snapshot sync already completed")
 		return nil

--- a/eth/protocols/snap/sync_test.go
+++ b/eth/protocols/snap/sync_test.go
@@ -2123,7 +2123,7 @@ func newDbConfig(scheme string) *triedb.Config {
 // TestBytecodeOnlyMode tests the bytecode-only sync mode
 func TestBytecodeOnlyMode(t *testing.T) {
 	t.Parallel()
-	
+
 	testBytecodeOnlyMode(t, rawdb.HashScheme)
 	testBytecodeOnlyMode(t, rawdb.PathScheme)
 }
@@ -2172,25 +2172,25 @@ func testBytecodeOnlyMode(t *testing.T, scheme string) {
 // TestBytecodeOnlyModeSimple tests basic bytecode-only sync functionality
 func TestBytecodeOnlyModeSimple(t *testing.T) {
 	t.Parallel()
-	
+
 	// Test that SetBytecodeOnlyMode can be called
 	scheme := rawdb.HashScheme
 	db := rawdb.NewMemoryDatabase()
 	syncer := NewSyncer(db, scheme)
-	
+
 	// Enable bytecode-only mode
 	syncer.SetBytecodeOnlyMode(true)
-	
+
 	// Verify the mode is set
 	syncer.lock.Lock()
 	if !syncer.bytecodeOnlyMode {
 		t.Error("Expected bytecode-only mode to be enabled")
 	}
 	syncer.lock.Unlock()
-	
+
 	// Disable bytecode-only mode
 	syncer.SetBytecodeOnlyMode(false)
-	
+
 	// Verify the mode is unset
 	syncer.lock.Lock()
 	if syncer.bytecodeOnlyMode {
@@ -2202,7 +2202,7 @@ func TestBytecodeOnlyModeSimple(t *testing.T) {
 // TestBytecodeOnlyModeFiltering tests that bytecode-only mode affects sync behavior
 func TestBytecodeOnlyModeFiltering(t *testing.T) {
 	t.Parallel()
-	
+
 	var (
 		once   sync.Once
 		cancel = make(chan struct{})

--- a/eth/protocols/wit/handler.go
+++ b/eth/protocols/wit/handler.go
@@ -47,7 +47,6 @@ type Backend interface {
 func MakeProtocols(backend Backend, network uint64) []p2p.Protocol {
 	protocols := make([]p2p.Protocol, 0, len(ProtocolVersions))
 	for _, version := range ProtocolVersions {
-		version := version // Closure
 		protocols = append(protocols, p2p.Protocol{
 			Name:    ProtocolName,
 			Version: version,
@@ -70,7 +69,6 @@ func MakeProtocols(backend Backend, network uint64) []p2p.Protocol {
 			// TODO(@pratikspatil024) - check if we need this
 			Attributes: []enr.Entry{currentENREntry(backend.Chain())},
 		})
-
 	}
 
 	return protocols

--- a/eth/protocols/wit/protocol.go
+++ b/eth/protocols/wit/protocol.go
@@ -35,14 +35,9 @@ const (
 )
 
 var (
-	errNoStatusMsg             = errors.New("no status message")
-	errMsgTooLarge             = errors.New("message too long")
-	errDecode                  = errors.New("invalid message")
-	errInvalidMsgCode          = errors.New("invalid message code")
-	errProtocolVersionMismatch = errors.New("protocol version mismatch")
-	errNetworkIDMismatch       = errors.New("network ID mismatch")
-	errGenesisMismatch         = errors.New("genesis mismatch")
-	errForkIDRejected          = errors.New("fork ID rejected")
+	errMsgTooLarge    = errors.New("message too long")
+	errDecode         = errors.New("invalid message")
+	errInvalidMsgCode = errors.New("invalid message code")
 )
 
 // Packet represents a p2p message in the `wit` protocol.

--- a/eth/sync.go
+++ b/eth/sync.go
@@ -191,7 +191,7 @@ func peerToSyncOp(mode downloader.SyncMode, p *eth.Peer) *chainSyncOp {
 
 func (cs *chainSyncer) modeAndLocalHead() (downloader.SyncMode, *big.Int) {
 	// If we're in snap sync mode, return that directly
-	if cs.handler.snapSync.Load() {
+	if cs.handler.snapSync.Load() && !cs.handler.statelessSync.Load() {
 		block := cs.handler.chain.CurrentSnapBlock()
 		td := cs.handler.chain.GetTd(block.Hash(), block.Number.Uint64())
 		return downloader.SnapSync, td
@@ -200,7 +200,7 @@ func (cs *chainSyncer) modeAndLocalHead() (downloader.SyncMode, *big.Int) {
 	// We are probably in full sync, but we might have rewound to before the
 	// snap sync pivot, check if we should re-enable snap sync.
 	head := cs.handler.chain.CurrentBlock()
-	if pivot := rawdb.ReadLastPivotNumber(cs.handler.database); pivot != nil {
+	if pivot := rawdb.ReadLastPivotNumber(cs.handler.database); pivot != nil && !cs.handler.statelessSync.Load() {
 		if head.Number.Uint64() < *pivot {
 			block := cs.handler.chain.CurrentSnapBlock()
 			td := cs.handler.chain.GetTd(block.Hash(), block.Number.Uint64())

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -767,7 +767,6 @@ func (api *BlockChainAPI) GetBlockReceipts(ctx context.Context, blockNrOrHash rp
 
 // GetTdByHash returns a map containing the total difficulty (hex-encoded) for the given block hash.
 func (api *BlockChainAPI) GetTdByHash(ctx context.Context, hash common.Hash) map[string]interface{} {
-
 	td := api.b.GetTd(ctx, hash)
 	if td == nil {
 		return nil


### PR DESCRIPTION
Fixing byte code download when a stateless node needs to fast forward a recent block. 
The previous issue was that trie node healer in snap sync was disabled completely for stateless node. However, this led to a problem when the pivot of snap sync moves, resulting the node not being able to download all the contracts correctly.

This change will try to allow snap sync pivot to move when downloading bytecodes. Because of moving pivot, the node will need to go through trie node and byte code healing process. In order to speed up healing speed, the merkle path whose lengths are less than 6 nibbles or who leads to a bytecode trie node will be stored. 

In PoS mainnet (~74M blocks), the total contract size is approximately 30GB, and their associated trie nodes is 60GB. 