### PR TITLE
Improving fail handling from reorgs

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -278,16 +278,15 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 		eth.blockchain, err = core.NewBlockChain(chainDb, cacheConfig, config.Genesis, &overrides, eth.engine, vmConfig, eth.shouldPreserve, &config.TransactionHistory, checker)
 	}
 
-	// Set blockchain reference for fork detection in whitelist service
-	if err == nil {
-		checker.SetBlockchain(eth.blockchain)
-	}
-
-	// 1.14.8: NewOracle function definition was changed to accept (startPrice *big.Int) param.
-	eth.APIBackend.gpo = gasprice.NewOracle(eth.APIBackend, gpoParams, config.Miner.GasPrice)
 	if err != nil {
 		return nil, err
 	}
+
+	// Set blockchain reference for fork detection in whitelist service
+	checker.SetBlockchain(eth.blockchain)
+
+	// 1.14.8: NewOracle function definition was changed to accept (startPrice *big.Int) param.
+	eth.APIBackend.gpo = gasprice.NewOracle(eth.APIBackend, gpoParams, config.Miner.GasPrice)
 
 	// bor: this is nor present in geth
 	/*

--- a/eth/sync.go
+++ b/eth/sync.go
@@ -168,6 +168,10 @@ func (cs *chainSyncer) nextSyncOp() *chainSyncOp {
 	mode, ourTD := cs.modeAndLocalHead()
 	op := peerToSyncOp(mode, peer)
 
+	if ourTD == nil {
+		ourTD = big.NewInt(0)
+	}
+
 	if op.td.Cmp(ourTD) <= 0 {
 		// We seem to be in sync according to the legacy rules. In the merge
 		// world, it can also mean we're stuck on the merge block, waiting for

--- a/ethstats/ethstats.go
+++ b/ethstats/ethstats.go
@@ -789,7 +789,9 @@ func (s *Service) reportHistory(conn *connWrapper, list []uint64) error {
 		header, _ := s.backend.HeaderByNumber(context.Background(), rpc.BlockNumber(number))
 		if header != nil {
 			history[len(history)-1-i] = s.assembleBlockStats(header)
-			continue
+			if history[len(history)-1-i] != nil {
+				continue
+			}
 		}
 		// Ran out of blocks, cut the report short and send
 		history = history[len(history)-i:]


### PR DESCRIPTION
# Description

After the last issue occurred on Bor, a few nodes reported some crashes because of the reorgs. This PR address some of those issues by better logging and including a few more nil checks.

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes
