### PR TITLE
Stateless sync fix wit download

### DIFF
--- a/eth/downloader/bor_downloader_test.go
+++ b/eth/downloader/bor_downloader_test.go
@@ -372,6 +372,11 @@ func (dlp *downloadTesterPeer) RequestWitnesses(hashes []common.Hash, sink chan 
 	return nil, nil
 }
 
+// SupportsWitness implements Peer
+func (dlp *downloadTesterPeer) SupportsWitness() bool {
+	return false
+}
+
 // ID retrieves the peer's unique identifier.
 func (dlp *downloadTesterPeer) ID() string {
 	return dlp.id

--- a/eth/downloader/bor_fetchers_concurrent.go
+++ b/eth/downloader/bor_fetchers_concurrent.go
@@ -156,7 +156,7 @@ func (d *Downloader) concurrentFetch(queue typedQueue, beaconMode bool) error {
 						peer.log.Trace("Skipping peer for witness fetch - no witness support", "peer", peer.id)
 						continue
 					}
-					
+
 					idles = append(idles, peer)
 					caps = append(caps, queue.capacity(peer, time.Second))
 				} else if stale != nil {
@@ -230,7 +230,20 @@ func (d *Downloader) concurrentFetch(queue typedQueue, beaconMode bool) error {
 			}
 			// Make sure that we have peers available for fetching. If all peers have been tried
 			// and all failed throw an error
-			if !progressed && !throttled && len(pending) == 0 && len(idles) == d.peers.Len() && queued > 0 && !beaconMode {
+			var capablePeers int
+			if isWitnessQueue {
+				// For witness fetching, only count peers that support the witness protocol
+				for _, peer := range d.peers.AllPeers() {
+					if peer.peer.SupportsWitness() {
+						capablePeers++
+					}
+				}
+			} else {
+				// For other queues, all peers are capable
+				capablePeers = d.peers.Len()
+			}
+
+			if !progressed && !throttled && len(pending) == 0 && len(idles) == capablePeers && queued > 0 && !beaconMode {
 				return errPeersUnavailable
 			}
 		}

--- a/eth/downloader/bor_fetchers_concurrent_witnesses.go
+++ b/eth/downloader/bor_fetchers_concurrent_witnesses.go
@@ -85,6 +85,12 @@ func (q *witnessQueue) unreserve(peer string) int {
 // request is responsible for converting a generic fetch request into a witness
 // one and sending it to the remote peer for fulfillment using the wit protocol.
 func (q *witnessQueue) request(peer *peerConnection, req *fetchRequest, resCh chan *eth.Response) (*eth.Request, error) {
+	// Safety check: ensure the peer supports witness protocol
+	if !peer.peer.SupportsWitness() {
+		peer.log.Warn("Attempted to request witnesses from non-witness peer", "peer", peer.id)
+		return nil, errors.New("peer does not support witness protocol")
+	}
+
 	// Extract hashes from the headers in the fetch request.
 	hashes := make([]common.Hash, 0, len(req.Headers))
 	for _, header := range req.Headers {

--- a/eth/downloader/peer.go
+++ b/eth/downloader/peer.go
@@ -65,6 +65,9 @@ type Peer interface {
 	RequestBodies([]common.Hash, chan *eth.Response) (*eth.Request, error)
 	RequestReceipts([]common.Hash, chan *eth.Response) (*eth.Request, error)
 	RequestWitnesses([]common.Hash, chan *eth.Response) (*eth.Request, error)
+
+	// SupportsWitness returns true if the peer supports the witness protocol
+	SupportsWitness() bool
 }
 
 // newPeerConnection creates a new downloader peer.

--- a/eth/downloader/skeleton_test.go
+++ b/eth/downloader/skeleton_test.go
@@ -215,6 +215,10 @@ func (p *skeletonTestPeer) RequestWitnesses([]common.Hash, chan *eth.Response) (
 	panic("skeleton sync must not request witnesses")
 }
 
+func (p *skeletonTestPeer) SupportsWitness() bool {
+	return false
+}
+
 // Tests various sync initializations based on previous leftovers in the database
 // and announced heads.
 func TestSkeletonSyncInit(t *testing.T) {

--- a/eth/peer.go
+++ b/eth/peer.go
@@ -149,6 +149,12 @@ func (r *ethWitRequest) Close() error {
 	return nil
 }
 
+// SupportsWitness implements downloader.Peer.
+// It returns true if the peer supports the witness protocol.
+func (p *ethPeer) SupportsWitness() bool {
+	return p.witPeer != nil
+}
+
 // RequestWitnesses implements downloader.Peer.
 // It requests witnesses using the wit protocol for the given block hashes.
 func (p *ethPeer) RequestWitnesses(hashes []common.Hash, dlResCh chan *eth.Response) (*eth.Request, error) {


### PR DESCRIPTION
This change will avoid sending witness request to peers that don't support `wit` protocol. Also fixes a sync issue where witness queue is hanging due to the node is incorrectly waiting for peers that don't support `wit` protocol.