### PR TITLE
core/miner: observability for block building delays

### DIFF
--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -108,6 +108,10 @@ var (
 	throttleTxMeter = metrics.NewRegisteredMeter("txpool/throttle", nil)
 	// reorgDurationTimer measures how long time a txpool reorg takes.
 	reorgDurationTimer = metrics.NewRegisteredTimer("txpool/reorgtime", nil)
+	// reorgLockDurationTimer measures how long the global lock was held during
+	// a reorg. Note that this won't account for reheap as it happens without
+	// the global lock.
+	reorgLockDurationTimer = metrics.NewRegisteredTimer("txpool/reorglock", nil)
 	// dropBetweenReorgHistogram counts how many drops we experience between two reorg runs. It is expected
 	// that this number is pretty low, since txpool reorgs happen very frequently.
 	dropBetweenReorgHistogram = metrics.NewRegisteredHistogram("txpool/dropbetweenreorg", nil, metrics.NewExpDecaySample(1028, 0.015))
@@ -118,6 +122,12 @@ var (
 
 	resetCacheGauge = metrics.NewRegisteredGauge("txpool/resetcache", nil)
 	reheapTimer     = metrics.NewRegisteredTimer("txpool/reheap", nil)
+	// pendingLockWaitTimer measures how long the pending lock was held. This is useful
+	// to understand delay in block building and the impact of lock in it.
+	pendingLockWaitTimer = metrics.NewRegisteredTimer("txpool/pendinglockwait", nil)
+	// pendingWaitTimer measures the total time taken for a pending call. This is useful
+	// to understand delay in block building.
+	pendingWaitTimer = metrics.NewRegisteredTimer("txpool/pendingwait", nil)
 )
 
 // BlockChain defines the minimal set of methods needed to back a tx pool with
@@ -519,12 +529,20 @@ func (pool *LegacyPool) ContentFrom(addr common.Address) ([]*types.Transaction, 
 // reduce allocations and load on downstream subsystems. The retrieval is halted
 // if interrupt is set (during block building timeout).
 func (pool *LegacyPool) Pending(filter txpool.PendingFilter, interrupt *atomic.Bool) map[common.Address][]*txpool.LazyTransaction {
+	defer func(t0 time.Time) {
+		pendingWaitTimer.Update(time.Since(t0))
+	}(time.Now())
+
 	// If only blob transactions are requested, this pool is unsuitable as it
 	// contains none, don't even bother.
 	if filter.OnlyBlobTxs {
 		return nil
 	}
+
+	// Capture the time taken to acquire the lock
+	lockWait := time.Now()
 	pool.mu.Lock()
+	pendingLockWaitTimer.Update(time.Since(lockWait))
 	defer pool.mu.Unlock()
 
 	if interrupt == nil {
@@ -1333,6 +1351,7 @@ func (pool *LegacyPool) runReorg(done chan struct{}, reset *txpoolResetRequest, 
 		// the flatten operation can be avoided.
 		promoteAddrs = dirtyAccounts.flatten()
 	}
+	lockTime := time.Now()
 	pool.mu.Lock()
 	if reset != nil {
 		// Reset from the old head to the new, rescheduling any reorged transactions
@@ -1376,6 +1395,7 @@ func (pool *LegacyPool) runReorg(done chan struct{}, reset *txpoolResetRequest, 
 	pool.changesSinceReorg = 0 // Reset change counter
 
 	pool.mu.Unlock()
+	reorgLockDurationTimer.Update(time.Since(lockTime))
 
 	// Reheap if needed
 	if reset != nil {

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -122,8 +122,8 @@ var (
 
 	resetCacheGauge = metrics.NewRegisteredGauge("txpool/resetcache", nil)
 	reheapTimer     = metrics.NewRegisteredTimer("txpool/reheap", nil)
-	// pendingLockWaitTimer measures how long the pending lock was held. This is useful
-	// to understand delay in block building and the impact of lock in it.
+	// pendingLockWaitTimer measures how long it took to acquire the pending lock. This is useful
+	// to understand delay in block building and the impact of lock acquisition.
 	pendingLockWaitTimer = metrics.NewRegisteredTimer("txpool/pendinglockwait", nil)
 	// pendingWaitTimer measures the total time taken for a pending call. This is useful
 	// to understand delay in block building.

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -91,7 +91,7 @@ var (
 
 	// txHeapInitTimer measures time taken to initialise a heap of pending transactions from pool
 	txHeapInitTimer = metrics.NewRegisteredTimer("worker/txheapinit", nil)
-	// commitTransactionsTimer measures time taken to executed transactions
+	// commitTransactionsTimer measures time taken to execute transactions
 	commitTransactionsTimer = metrics.NewRegisteredTimer("worker/commitTransactions", nil)
 )
 

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -88,6 +88,11 @@ var (
 	sealedBlocksCounter      = metrics.NewRegisteredCounter("worker/sealedBlocks", nil)
 	sealedEmptyBlocksCounter = metrics.NewRegisteredCounter("worker/sealedEmptyBlocks", nil)
 	txCommitInterruptCounter = metrics.NewRegisteredCounter("worker/txCommitInterrupt", nil)
+
+	// txHeapInitTimer measures time taken to initialise a heap of pending transactions from pool
+	txHeapInitTimer = metrics.NewRegisteredTimer("worker/txheapinit", nil)
+	// commitTransactionsTimer measures time taken to executed transactions
+	commitTransactionsTimer = metrics.NewRegisteredTimer("worker/commitTransactions", nil)
 )
 
 // environment is the worker's current environment and holds all
@@ -915,6 +920,10 @@ func (w *worker) commitTransaction(env *environment, tx *types.Transaction) ([]*
 }
 
 func (w *worker) commitTransactions(env *environment, plainTxs, blobTxs *transactionsByPriceAndNonce, interrupt *atomic.Int32, minTip *uint256.Int) error {
+	defer func(t0 time.Time) {
+		commitTransactionsTimer.Update(time.Since(t0))
+	}(time.Now())
+
 	gasLimit := env.header.GasLimit
 	if env.gasPool == nil {
 		env.gasPool = new(core.GasPool).AddGas(gasLimit)
@@ -1370,8 +1379,10 @@ func (w *worker) fillTransactions(interrupt *atomic.Int32, env *environment) err
 		}
 	}
 	if len(normalPlainTxs) > 0 || len(normalBlobTxs) > 0 {
+		heapInitTime := time.Now()
 		plainTxs := newTransactionsByPriceAndNonce(env.signer, normalPlainTxs, env.header.BaseFee, &w.interruptBlockBuilding)
 		blobTxs := newTransactionsByPriceAndNonce(env.signer, normalBlobTxs, env.header.BaseFee, &w.interruptBlockBuilding)
+		txHeapInitTimer.Update(time.Since(heapInitTime))
 
 		if err := w.commitTransactions(env, plainTxs, blobTxs, interrupt, new(uint256.Int)); err != nil {
 			return err


### PR DESCRIPTION
# Description

Adds some observability to capture delays during block building. Mainly captures
1. Time taken to acquire lock in pending pool
2. Time taken for the whole pending call to finish (this matters the most for miner during block building)
3. Time taken to release the lock held during tx pool reorg
4. Time taken to init a heap out of the pending transactions before starting to execute transactions
5. Time taken to actually execute transactions in ideal mining workflow

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Nodes audience

In case this PR includes changes that must be applied only to a subset of nodes, please specify how you handled it (e.g. by adding a flag with a default value...)

# Checklist

- [ ] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [ ] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated

# Cross repository changes

- [ ] This PR requires changes to heimdall
    - In case link the PR here:
- [ ] This PR requires changes to matic-cli
    - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on amoy
- [ ] I have created new e2e tests into express-cli

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
