### PR TITLE
fix: build

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,11 @@
 module github.com/ethereum/go-ethereum
 
 // Note: Change the go image version in Dockerfile if you change this.
-go 1.24.4
+go 1.24.6
 
 require (
 	github.com/0xPolygon/crand v1.0.3
-	github.com/0xPolygon/heimdall-v2 v0.2.16-beta.0.20250806140653-d58ce649f932
+	github.com/0xPolygon/heimdall-v2 v0.2.16-beta.0.20250808133002-2a5044148f79
 	github.com/0xPolygon/polyproto v0.0.7
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.3.2
 	github.com/BurntSushi/toml v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -76,10 +76,8 @@ github.com/0xPolygon/cosmos-sdk/client/v2 v2.0.0-beta.1 h1:XV7f44uAJ1p1w9j15uzm2
 github.com/0xPolygon/cosmos-sdk/client/v2 v2.0.0-beta.1/go.mod h1:JEUSu9moNZQ4kU3ir1DKD5eU4bllmAexrGWjmb9k8qU=
 github.com/0xPolygon/crand v1.0.3 h1:BYYflmgLhmGPEgqtopG4muq6wV6DOkwD8uPymNz5WeQ=
 github.com/0xPolygon/crand v1.0.3/go.mod h1:km4366oC7EVFl1xNUCwzxUXNM10swZqd8LZ0E5SgbAE=
-github.com/0xPolygon/heimdall-v2 v0.2.16-beta.0.20250806094653-f76a382c4af2 h1:nNNhFytlNtuGmjKexvT4sILtlKRMZunVzOUly9qwTms=
-github.com/0xPolygon/heimdall-v2 v0.2.16-beta.0.20250806094653-f76a382c4af2/go.mod h1:g9xSiFSn5WT24reRAOyfb4qwktKyzFdbjeL/zlOHC0I=
-github.com/0xPolygon/heimdall-v2 v0.2.16-beta.0.20250806140653-d58ce649f932 h1:EdJvr+Aq/AjFX0orVOVpgayFQH2h/Veh+6RuMwd37uI=
-github.com/0xPolygon/heimdall-v2 v0.2.16-beta.0.20250806140653-d58ce649f932/go.mod h1:bjPFHwnFdLk64wWO8ioPjzcM6xqwFB8l7kmg8TB2ZRw=
+github.com/0xPolygon/heimdall-v2 v0.2.16-beta.0.20250808133002-2a5044148f79 h1:up1yqQ0gj4TmX46tFHMDP5QFAmO+jkJ2YvIlNTFNzio=
+github.com/0xPolygon/heimdall-v2 v0.2.16-beta.0.20250808133002-2a5044148f79/go.mod h1:/IYUm6D63SNsREv2U/TwEYIiKHnB12+1zBc1tyZQXY0=
 github.com/0xPolygon/polyproto v0.0.7 h1:Ody+kFyCRK4QXRPXbsP5pdxKrDgwAAXtFB8NPgaIxRs=
 github.com/0xPolygon/polyproto v0.0.7/go.mod h1:2Iw93k2LismvckKKeXQITuhJH9vLbqOa212AMskH6no=
 github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4 h1:/vQbFIOMbk2FiG/kXiLl8BRyzTWDw7gX/Hz7Dd5eDMs=


### PR DESCRIPTION
# Description

Since we merged [this](https://github.com/0xPolygon/heimdall-v2/pull/420) PR using a squash merge, the `d58ce649f932` commit was lost, and a new commit was created instead. This PR fixes that using the latest commit on the `develop` branch of heimdall-v2.

Error:
```bash
make bor
mkdir -p /Users/krishangshah/go/bin/
go build -o /Users/krishangshah/polygon/bor/build/bin/bor -ldflags "-X github.com/ethereum/go-ethereum/params.GitCommit=af0b8f5e5a300b01a1accb8b4d9ec3ffa21c1a14" ./cmd/cli/main.go
go: downloading github.com/0xPolygon/heimdall-v2 v0.2.16-beta.0.20250806140653-d58ce649f932
go: github.com/0xPolygon/heimdall-v2@v0.2.16-beta.0.20250806140653-d58ce649f932: invalid version: unknown revision d58ce649f932
make: *** [bor] Error 1
```