### PR TITLE
fix: dbcmd

### DIFF
--- a/cmd/geth/dbcmd.go
+++ b/cmd/geth/dbcmd.go
@@ -330,7 +330,7 @@ func inspect(ctx *cli.Context) error {
 	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
 
-	db := utils.MakeChainDatabase(ctx, stack, true, false)
+	db := utils.MakeChainDatabase(ctx, stack, true, true)
 	defer db.Close()
 
 	return rawdb.InspectDatabase(db, prefix, start)
@@ -357,7 +357,7 @@ func checkStateContent(ctx *cli.Context) error {
 	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
 
-	db := utils.MakeChainDatabase(ctx, stack, true, false)
+	db := utils.MakeChainDatabase(ctx, stack, true, true)
 	defer db.Close()
 
 	var (
@@ -416,7 +416,7 @@ func dbStats(ctx *cli.Context) error {
 	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
 
-	db := utils.MakeChainDatabase(ctx, stack, true, false)
+	db := utils.MakeChainDatabase(ctx, stack, true, true)
 	defer db.Close()
 
 	showDBStats(db)
@@ -454,7 +454,7 @@ func dbGet(ctx *cli.Context) error {
 	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
 
-	db := utils.MakeChainDatabase(ctx, stack, true, false)
+	db := utils.MakeChainDatabase(ctx, stack, true, true)
 	defer db.Close()
 
 	key, err := common.ParseHexOrString(ctx.Args().Get(0))
@@ -553,7 +553,7 @@ func dbDumpTrie(ctx *cli.Context) error {
 	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
 
-	db := utils.MakeChainDatabase(ctx, stack, true, false)
+	db := utils.MakeChainDatabase(ctx, stack, true, true)
 	defer db.Close()
 
 	triedb := utils.MakeTrieDatabase(ctx, db, false, true, false)
@@ -800,7 +800,7 @@ func exportChaindata(ctx *cli.Context) error {
 		close(stop)
 	}()
 
-	db := utils.MakeChainDatabase(ctx, stack, true, false)
+	db := utils.MakeChainDatabase(ctx, stack, true, true)
 	defer db.Close()
 	return utils.ExportChaindata(ctx.Args().Get(1), kind, exporter(db), stop)
 }
@@ -808,7 +808,7 @@ func exportChaindata(ctx *cli.Context) error {
 func showMetaData(ctx *cli.Context) error {
 	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
-	db := utils.MakeChainDatabase(ctx, stack, true, false)
+	db := utils.MakeChainDatabase(ctx, stack, true, true)
 	ancients, err := db.Ancients()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error accessing ancients: %v", err)
@@ -926,7 +926,7 @@ func inspectHistory(ctx *cli.Context) error {
 	stack, _ := makeConfigNode(ctx)
 	defer stack.Close()
 
-	db := utils.MakeChainDatabase(ctx, stack, true, false)
+	db := utils.MakeChainDatabase(ctx, stack, true, true)
 	defer db.Close()
 
 	triedb := utils.MakeTrieDatabase(ctx, db, false, false, false)

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1388,6 +1388,11 @@ func setEtherbase(ctx *cli.Context, cfg *ethconfig.Config) {
 
 	addr := ctx.String(MinerEtherbaseFlag.Name)
 
+	// If no etherbase is specified, return.
+	if addr == "" {
+		return
+	}
+
 	if strings.HasPrefix(addr, "0x") || strings.HasPrefix(addr, "0X") {
 		addr = addr[2:]
 	}


### PR DESCRIPTION
# Description

ref https://polygon.atlassian.net/browse/POS-3035

This is the updated response from `posdevnodes-mainnet-bor-2`:

```bash
~/bor$ sudo go run ./cmd/geth db metadata --datadir /var/lib/bor/data/
INFO [08-21|09:50:40.491] Maximum peer count                       ETH=50 total=50
INFO [08-21|09:50:40.492] Smartcard socket not found, disabling    err="stat /run/pcscd/pcscd.comm: no such file or directory"
INFO [08-21|09:50:40.495] Set global gas cap                       cap=50,000,000
INFO [08-21|09:50:40.495] Initializing the KZG library             backend=gokzg
INFO [08-21|09:50:40.702] Using pebble as the backing database
INFO [08-21|09:50:40.702] Allocated cache and file handles         database=/var/lib/bor/data/bor/chaindata cache=512.00MiB handles=524,288
INFO [08-21|09:50:42.220] Resolving ancient pruner offset          isLastOffset=false offset=0
INFO [08-21|09:50:49.973] Opened ancient database                  database=/var/lib/bor/data/bor/chaindata/ancient/chain readonly=true frozen=75,382,741 offset=0
+-------------------------+--------------------------------------------------------------------+
|          FIELD          |                               VALUE                                |
+-------------------------+--------------------------------------------------------------------+
| databaseVersion         | 9 (0x9)                                                            |
| headBlockHash           | 0x99817c91796af8774eaf1d87c7dcbdfe50b8b84192f63a199d31c73b9ab61d9c |
| headFastBlockHash       | 0x99817c91796af8774eaf1d87c7dcbdfe50b8b84192f63a199d31c73b9ab61d9c |
| headHeaderHash          | 0x99817c91796af8774eaf1d87c7dcbdfe50b8b84192f63a199d31c73b9ab61d9c |
| lastPivotNumber         | 74696527 (0x473c74f)                                               |
| len(snapshotSyncStatus) | 291 bytes                                                          |
| snapshotDisabled        | false                                                              |
| snapshotJournal         | 8544936 bytes                                                      |
| snapshotRecoveryNumber  | <nil>                                                              |
| snapshotRoot            | 0x95d4723d6efb07d19a8bbac00c8abaf483c9e5bbaccfbca049c93e98170440bc |
| txIndexTail             | 73122758 (0x45bc3c6)                                               |
| filterMapsRange         | {Version:2 HeadIndexed:true                                        |
|                         | HeadDelimiter:119707773915                                         |
|                         | BlocksFirst:73103912                                               |
|                         | BlocksAfterLast:75472758                                           |
|                         | MapsFirst:1726464                                                  |
|                         | MapsAfterLast:1826596                                              |
|                         | TailPartialEpoch:0}                                                |
| frozen                  | 75382741 items                                                     |
| snapshotGenerator       | Done: true, Accounts: 0,                                           |
|                         | Slots: 0, Storage: 0, Marker:                                      |
| headBlock.Hash          | 0x99817c91796af8774eaf1d87c7dcbdfe50b8b84192f63a199d31c73b9ab61d9c |
| headBlock.Root          | 0xca12cc929d175cc71b82d099797f872b3113c4226963929561f97ad775d7038d |
| headBlock.Number        | 75472757 (0x47f9f75)                                               |
| headHeader.Hash         | 0x99817c91796af8774eaf1d87c7dcbdfe50b8b84192f63a199d31c73b9ab61d9c |
| headHeader.Root         | 0xca12cc929d175cc71b82d099797f872b3113c4226963929561f97ad775d7038d |
| headHeader.Number       | 75472757 (0x47f9f75)                                               |
+-------------------------+--------------------------------------------------------------------+

~/bor$ sudo go run ./cmd/geth db stats --datadir /var/lib/bor/data/
INFO [08-21|09:51:06.722] Maximum peer count                       ETH=50 total=50
INFO [08-21|09:51:06.724] Smartcard socket not found, disabling    err="stat /run/pcscd/pcscd.comm: no such file or directory"
INFO [08-21|09:51:06.726] Set global gas cap                       cap=50,000,000
INFO [08-21|09:51:06.727] Initializing the KZG library             backend=gokzg
INFO [08-21|09:51:06.771] Using pebble as the backing database
INFO [08-21|09:51:06.771] Allocated cache and file handles         database=/var/lib/bor/data/bor/chaindata cache=512.00MiB handles=524,288
INFO [08-21|09:51:08.298] Resolving ancient pruner offset          isLastOffset=false offset=0
INFO [08-21|09:51:15.819] Opened ancient database                  database=/var/lib/bor/data/bor/chaindata/ancient/chain readonly=true frozen=75,382,741 offset=0
      |                             |       |       |   ingested   |     moved    |    written   |       |    amp
level | tables  size val-bl vtables | score |   in  | tables  size | tables  size | tables  size |  read |   r   w
------+-----------------------------+-------+-------+--------------+--------------+--------------+-------+---------
    0 |    19  392MB     0B       0 |  1.22 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
    1 |    16   53MB     0B       0 |  0.82 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
    2 |    92  431MB     0B       0 |  0.96 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
    3 |   419  3.0GB     0B       0 |  0.96 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
    4 |  1.4K   21GB     0B       0 |  0.95 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
    5 |   25K  150GB     0B       0 |  0.98 |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
    6 |   19K 1014GB     0B       0 |     - |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
total |   47K  1.2TB     0B       0 |     - |    0B |     0     0B |     0     0B |     0     0B |    0B |   0  0.0
-------------------------------------------------------------------------------------------------------------------
WAL: 1 files (0B)  in: 0B  written: 0B (0% overhead)
Flushes: 0
Compactions: 0  estimated debt: 4.4GB  in progress: 0 (0B)
             default: 0  delete: 0  elision: 0  move: 0  read: 0  rewrite: 0  multi-level: 0
MemTables: 1 (256KB)  zombie: 0 (0B)
Zombie tables: 0 (0B)
Backing tables: 0 (0B)
Virtual tables: 0 (0B)
Block cache: 53 entries (4.8MB)  hit rate: 32.4%
Table cache: 16 entries (13KB)  hit rate: 50.0%
Secondary cache: 0 entries (0B)  hit rate: 0.0%
Snapshots: 0  earliest seq num: 0
Table iters: 0
Filter utility: 96.4%
Ingestions: 0  as flushable: 0 (0B in 0 tables)
```