### PR TITLE
Remove explicit wait for span rotation

### DIFF
--- a/consensus/bor/bor.go
+++ b/consensus/bor/bor.go
@@ -737,21 +737,7 @@ func (c *Bor) performSpanCheck(chain consensus.ChainHeaderReader, targetHeader *
 		log.Info("Span check complete", "foundNewSpan", foundNewSpan)
 
 		return nil
-	} else if missingTargetSignature == nil && targetHeaderAuthor != parentHeaderAuthor {
-		log.Info("Updating latest span due to different author", "target block", targetHeader.Number.Uint64(), "parentHeader", targetHeader.ParentHash, "parentHeaderAuthor", parentHeaderAuthor, "targetHeaderAuthor", targetHeaderAuthor)
-
-		// We don't want to wait for a new span forever if the target header author is different from the parent header author, because it would lead to a deadlock if the header is signed by a malicious producer who is not in the validator set.
-		foundNewSpan, err := c.spanStore.waitForNewSpan(targetHeader.Number.Uint64(), parentHeaderAuthor, veblopBlockTimeout)
-		if err != nil {
-			log.Warn("Error while waiting for new span", "error", err)
-			return err
-		}
-
-		log.Info("Span check complete", "foundNewSpan", foundNewSpan)
-
-		return nil
 	}
-
 	return nil
 }
 

--- a/consensus/bor/heimdall.go
+++ b/consensus/bor/heimdall.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ethereum/go-ethereum/consensus/bor/heimdall/milestone"
 
 	"github.com/0xPolygon/heimdall-v2/x/bor/types"
+	ctypes "github.com/cometbft/cometbft/rpc/core/types"
 )
 
 //go:generate mockgen -source=heimdall.go -destination=../../tests/bor/mocks/IHeimdallClient.go -package=mocks
@@ -19,6 +20,7 @@ type IHeimdallClient interface {
 	FetchCheckpointCount(ctx context.Context) (int64, error)
 	FetchMilestone(ctx context.Context) (*milestone.Milestone, error)
 	FetchMilestoneCount(ctx context.Context) (int64, error)
+	FetchStatus(ctx context.Context) (*ctypes.SyncInfo, error)
 	Close()
 }
 

--- a/consensus/bor/heimdall/client.go
+++ b/consensus/bor/heimdall/client.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/0xPolygon/heimdall-v2/x/bor/types"
 	clerkTypes "github.com/0xPolygon/heimdall-v2/x/clerk/types"
+	ctypes "github.com/cometbft/cometbft/rpc/core/types"
 	"github.com/cosmos/cosmos-sdk/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
@@ -77,6 +78,8 @@ const (
 
 	fetchSpanFormat = "bor/spans/%d"
 	fetchLatestSpan = "bor/spans/latest"
+
+	fetchStatus = "/status"
 )
 
 // StateSyncEvents fetches the state sync events from heimdall
@@ -229,6 +232,22 @@ func (h *HeimdallClient) FetchMilestoneCount(ctx context.Context) (int64, error)
 		return 0, err
 	}
 	return response.Count, nil
+}
+
+func (h *HeimdallClient) FetchStatus(ctx context.Context) (*ctypes.SyncInfo, error) {
+	ctx = WithRequestType(ctx, StatusRequest)
+
+	url, err := statusURL(h.urlString)
+	if err != nil {
+		return nil, err
+	}
+
+	response, err := FetchWithRetry[ctypes.SyncInfo](ctx, h.client, url, h.closeCh)
+	if err != nil {
+		return nil, err
+	}
+
+	return response, nil
 }
 
 // FetchWithRetry returns data from heimdall with retry
@@ -392,6 +411,10 @@ func checkpointCountURL(urlString string) (*url.URL, error) {
 
 func milestoneCountURL(urlString string) (*url.URL, error) {
 	return makeURL(urlString, fetchMilestoneCount, "")
+}
+
+func statusURL(urlString string) (*url.URL, error) {
+	return makeURL(urlString, fetchStatus, "")
 }
 
 func makeURL(urlString, rawPath, rawQuery string) (*url.URL, error) {

--- a/consensus/bor/heimdall/metrics.go
+++ b/consensus/bor/heimdall/metrics.go
@@ -28,6 +28,7 @@ const (
 	MilestoneNoAckRequest     requestType = "milestone-no-ack"
 	MilestoneLastNoAckRequest requestType = "milestone-last-no-ack"
 	MilestoneIDRequest        requestType = "milestone-id"
+	StatusRequest             requestType = "status"
 )
 
 func WithRequestType(ctx context.Context, reqType requestType) context.Context {

--- a/consensus/bor/heimdallgrpc/client.go
+++ b/consensus/bor/heimdallgrpc/client.go
@@ -1,6 +1,7 @@
 package heimdallgrpc
 
 import (
+	"context"
 	"strings"
 	"time"
 
@@ -8,7 +9,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
 
-	protoV1 "github.com/0xPolygon/polyproto/heimdall"
+	"github.com/ethereum/go-ethereum/consensus/bor/heimdall"
 	"github.com/ethereum/go-ethereum/log"
 	grpcRetry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
 
@@ -16,6 +17,7 @@ import (
 	checkpointTypes "github.com/0xPolygon/heimdall-v2/x/checkpoint/types"
 	clerkTypes "github.com/0xPolygon/heimdall-v2/x/clerk/types"
 	milestoneTypes "github.com/0xPolygon/heimdall-v2/x/milestone/types"
+	ctypes "github.com/cometbft/cometbft/rpc/core/types"
 )
 
 const (
@@ -25,15 +27,15 @@ const (
 
 type HeimdallGRPCClient struct {
 	conn                  *grpc.ClientConn
-	client                protoV1.HeimdallClient
+	client                *heimdall.HeimdallClient
 	borQueryClient        borTypes.QueryClient
 	checkpointQueryClient checkpointTypes.QueryClient
 	clerkQueryClient      clerkTypes.QueryClient
 	milestoneQueryClient  milestoneTypes.QueryClient
 }
 
-func NewHeimdallGRPCClient(address string) *HeimdallGRPCClient {
-	address = removePrefix(address)
+func NewHeimdallGRPCClient(grpcAddress string, heimdallURL string, timeout time.Duration) *HeimdallGRPCClient {
+	grpcAddress = removePrefix(grpcAddress)
 
 	opts := []grpcRetry.CallOption{
 		grpcRetry.WithMax(10000),
@@ -41,7 +43,7 @@ func NewHeimdallGRPCClient(address string) *HeimdallGRPCClient {
 		grpcRetry.WithCodes(codes.Internal, codes.Unavailable, codes.Aborted, codes.NotFound),
 	}
 
-	conn, err := grpc.NewClient(address,
+	conn, err := grpc.NewClient(grpcAddress,
 		grpc.WithStreamInterceptor(grpcRetry.StreamClientInterceptor(opts...)),
 		grpc.WithUnaryInterceptor(grpcRetry.UnaryClientInterceptor(opts...)),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
@@ -50,11 +52,11 @@ func NewHeimdallGRPCClient(address string) *HeimdallGRPCClient {
 		log.Crit("Failed to connect to Heimdall gRPC", "error", err)
 	}
 
-	log.Info("Connected to Heimdall gRPC server", "address", address)
+	log.Info("Connected to Heimdall gRPC server", "grpcAddress", grpcAddress)
 
 	return &HeimdallGRPCClient{
 		conn:                  conn,
-		client:                protoV1.NewHeimdallClient(conn),
+		client:                heimdall.NewHeimdallClient(heimdallURL, timeout),
 		borQueryClient:        borTypes.NewQueryClient(conn),
 		checkpointQueryClient: checkpointTypes.NewQueryClient(conn),
 		clerkQueryClient:      clerkTypes.NewQueryClient(conn),
@@ -73,4 +75,8 @@ func removePrefix(address string) string {
 		return address[strings.Index(address, "//")+2:]
 	}
 	return address
+}
+
+func (h *HeimdallGRPCClient) FetchStatus(ctx context.Context) (*ctypes.SyncInfo, error) {
+	return h.client.FetchStatus(ctx)
 }

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -251,6 +251,8 @@ func CreateConsensusEngine(chainConfig *params.ChainConfig, ethConfig *Config, d
 		genesisContractsClient := contract.NewGenesisContractsClient(chainConfig, chainConfig.Bor.ValidatorContract, chainConfig.Bor.StateReceiverContract, blockchainAPI)
 		spanner := span.NewChainSpanner(blockchainAPI, contract.ValidatorSet(), chainConfig, common.HexToAddress(chainConfig.Bor.ValidatorContract))
 
+		log.Info("Creating consensus engine", "withoutHeimdall", ethConfig.WithoutHeimdall)
+
 		if ethConfig.WithoutHeimdall {
 			return bor.New(chainConfig, db, blockchainAPI, spanner, nil, nil, genesisContractsClient, ethConfig.DevFakeAuthor), nil
 		} else {
@@ -264,7 +266,7 @@ func CreateConsensusEngine(chainConfig *params.ChainConfig, ethConfig *Config, d
 				// heimdallClient = heimdallapp.NewHeimdallAppClient()
 				panic("Running heimdall from bor is not implemented yet. Please use heimdall gRPC or HTTP client instead.")
 			} else if ethConfig.HeimdallgRPCAddress != "" {
-				heimdallClient = heimdallgrpc.NewHeimdallGRPCClient(ethConfig.HeimdallgRPCAddress)
+				heimdallClient = heimdallgrpc.NewHeimdallGRPCClient(ethConfig.HeimdallgRPCAddress, ethConfig.HeimdallURL, ethConfig.HeimdallTimeout)
 			} else {
 				heimdallClient = heimdall.NewHeimdallClient(ethConfig.HeimdallURL, ethConfig.HeimdallTimeout)
 			}

--- a/eth/handler_bor_test.go
+++ b/eth/handler_bor_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/0xPolygon/heimdall-v2/x/bor/types"
 	"github.com/stretchr/testify/require"
 
+	ctypes "github.com/cometbft/cometbft/rpc/core/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus/bor"
 	"github.com/ethereum/go-ethereum/consensus/bor/clerk"
@@ -59,6 +60,10 @@ func (m *mockHeimdall) FetchMilestoneCount(ctx context.Context) (int64, error) {
 }
 
 func (m *mockHeimdall) Close() {}
+
+func (m *mockHeimdall) FetchStatus(ctx context.Context) (*ctypes.SyncInfo, error) {
+	return &ctypes.SyncInfo{CatchingUp: false}, nil
+}
 
 func TestFetchWhitelistCheckpointAndMilestone(t *testing.T) {
 	t.Parallel()

--- a/miner/fake_miner.go
+++ b/miner/fake_miner.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	borTypes "github.com/0xPolygon/heimdall-v2/x/bor/types"
+	ctypes "github.com/cometbft/cometbft/rpc/core/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/consensus/bor"
@@ -67,6 +68,7 @@ func NewBorDefaultMiner(t *testing.T) *DefaultBorMiner {
 	heimdallClient.EXPECT().GetSpan(gomock.Any(), uint64(0)).Return(&span0, nil).AnyTimes()
 	heimdallClient.EXPECT().GetLatestSpan(gomock.Any()).Return(&span0, nil).AnyTimes()
 	heimdallClient.EXPECT().FetchMilestone(gomock.Any()).Return(&milestone.Milestone{}, nil).AnyTimes()
+	heimdallClient.EXPECT().FetchStatus(gomock.Any()).Return(&ctypes.SyncInfo{CatchingUp: false}, nil).AnyTimes()
 	heimdallClient.EXPECT().Close().Times(1)
 
 	genesisContracts := bor.NewMockGenesisContract(ctrl)

--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	ctypes "github.com/cometbft/cometbft/rpc/core/types"
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus"
@@ -398,6 +399,7 @@ func getFakeBorFromConfig(t *testing.T, chainConfig *params.ChainConfig) (consen
 	heimdallClientMock.EXPECT().GetSpan(gomock.Any(), uint64(0)).Return(&span0, nil).AnyTimes()
 	heimdallClientMock.EXPECT().GetLatestSpan(gomock.Any()).Return(&span0, nil).AnyTimes()
 	heimdallClientMock.EXPECT().FetchMilestone(gomock.Any()).Return(&milestone.Milestone{}, nil).AnyTimes()
+	heimdallClientMock.EXPECT().FetchStatus(gomock.Any()).Return(&ctypes.SyncInfo{CatchingUp: false}, nil).AnyTimes()
 	heimdallClientMock.EXPECT().Close().AnyTimes()
 
 	contractMock := bor.NewMockGenesisContract(ctrl)
@@ -1010,6 +1012,7 @@ func BenchmarkBorMining(b *testing.B) {
 	}, nil).AnyTimes()
 
 	heimdallClientMock := mocks.NewMockIHeimdallClient(ctrl)
+	heimdallClientMock.EXPECT().FetchStatus(gomock.Any()).Return(&ctypes.SyncInfo{CatchingUp: false}, nil).AnyTimes()
 	heimdallWSClient := mocks.NewMockIHeimdallWSClient(ctrl)
 
 	heimdallClientMock.EXPECT().Close().Times(1)
@@ -1109,6 +1112,7 @@ func BenchmarkBorMiningBlockSTMMetadata(b *testing.B) {
 	}, nil).AnyTimes()
 
 	heimdallClientMock := mocks.NewMockIHeimdallClient(ctrl)
+	heimdallClientMock.EXPECT().FetchStatus(gomock.Any()).Return(&ctypes.SyncInfo{CatchingUp: false}, nil).AnyTimes()
 	heimdallWSClient := mocks.NewMockIHeimdallWSClient(ctrl)
 	heimdallClientMock.EXPECT().Close().Times(1)
 

--- a/tests/bor/helper.go
+++ b/tests/bor/helper.go
@@ -53,6 +53,7 @@ import (
 	"github.com/ethereum/go-ethereum/triedb"
 
 	borTypes "github.com/0xPolygon/heimdall-v2/x/bor/types"
+	ctypes "github.com/cometbft/cometbft/rpc/core/types"
 )
 
 var (
@@ -430,6 +431,7 @@ func getMockedHeimdallClient(t *testing.T, heimdallSpan *borTypes.Span) (*mocks.
 
 	h.EXPECT().GetSpan(gomock.Any(), uint64(1)).Return(heimdallSpan, nil).AnyTimes()
 	h.EXPECT().StateSyncEvents(gomock.Any(), gomock.Any(), gomock.Any()).Return([]*clerk.EventRecordWithTime{getSampleEventRecord(t)}, nil).AnyTimes()
+	h.EXPECT().FetchStatus(gomock.Any()).Return(&ctypes.SyncInfo{CatchingUp: false}, nil).AnyTimes()
 
 	return h, ctrl
 }
@@ -467,6 +469,7 @@ func createMockHeimdall(ctrl *gomock.Controller, span0, span1 *borTypes.Span) *m
 	h.EXPECT().GetLatestSpan(gomock.Any()).Return(span1, nil).AnyTimes()
 	h.EXPECT().FetchCheckpoint(gomock.Any(), int64(-1)).Return(&checkpoint.Checkpoint{}, nil).AnyTimes()
 	h.EXPECT().FetchMilestone(gomock.Any()).Return(&milestone.Milestone{}, nil).AnyTimes()
+	h.EXPECT().FetchStatus(gomock.Any()).Return(&ctypes.SyncInfo{CatchingUp: false}, nil).AnyTimes()
 
 	return h
 }

--- a/tests/bor/mocks/IHeimdallClient.go
+++ b/tests/bor/mocks/IHeimdallClient.go
@@ -14,6 +14,7 @@ import (
 	reflect "reflect"
 
 	types "github.com/0xPolygon/heimdall-v2/x/bor/types"
+	coretypes "github.com/cometbft/cometbft/rpc/core/types"
 	clerk "github.com/ethereum/go-ethereum/consensus/bor/clerk"
 	checkpoint "github.com/ethereum/go-ethereum/consensus/bor/heimdall/checkpoint"
 	milestone "github.com/ethereum/go-ethereum/consensus/bor/heimdall/milestone"
@@ -114,6 +115,21 @@ func (m *MockIHeimdallClient) FetchMilestoneCount(ctx context.Context) (int64, e
 func (mr *MockIHeimdallClientMockRecorder) FetchMilestoneCount(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchMilestoneCount", reflect.TypeOf((*MockIHeimdallClient)(nil).FetchMilestoneCount), ctx)
+}
+
+// FetchStatus mocks base method.
+func (m *MockIHeimdallClient) FetchStatus(ctx context.Context) (*coretypes.SyncInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FetchStatus", ctx)
+	ret0, _ := ret[0].(*coretypes.SyncInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FetchStatus indicates an expected call of FetchStatus.
+func (mr *MockIHeimdallClientMockRecorder) FetchStatus(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchStatus", reflect.TypeOf((*MockIHeimdallClient)(nil).FetchStatus), ctx)
 }
 
 // GetLatestSpan mocks base method.


### PR DESCRIPTION
# Description

This change will remove a explicit wait for span changes if an incoming block has a different author from its parent block. Previously, this wait was added to prevent the case where a span rotation happens but local heimdall hasn't received the new span.

This waiting mechanism is now replaced by a check that will make sure bor will be blocked until heimdall has synced to the tip. The same check will also resolve an issue where bor might retrieve incorrect state sync events when heimdall isn't in sync.


# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Checklist

- [x] I have added at least 2 reviewer or the whole pos-v1 team
- [x] I have added sufficient documentation in code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [ ] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated

# Cross repository changes

- [ ] This PR requires changes to heimdall
    - In case link the PR here:
- [ ] This PR requires changes to matic-cli
    - In case link the PR here:

## Testing

- [x] I have added unit tests
- [ ] I have added tests to CI
- [x] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on amoy
- [ ] I have created new e2e tests into express-cli
