### PR TITLE
feat: witness rpc endpoints

### DIFF
--- a/eth/filters/IBackend.go
+++ b/eth/filters/IBackend.go
@@ -1007,3 +1007,48 @@ func (mr *MockBackendMockRecorder) UnprotectedAllowed() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnprotectedAllowed", reflect.TypeOf((*MockBackend)(nil).UnprotectedAllowed))
 }
+
+// WitnessByHash mocks base method.
+func (m *MockBackend) WitnessByHash(ctx context.Context, hash common.Hash) (*stateless.Witness, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WitnessByHash", ctx, hash)
+	ret0, _ := ret[0].(*stateless.Witness)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WitnessByHash indicates an expected call of WitnessByHash.
+func (mr *MockBackendMockRecorder) WitnessByHash(ctx, hash any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WitnessByHash", reflect.TypeOf((*MockBackend)(nil).WitnessByHash), ctx, hash)
+}
+
+// WitnessByNumber mocks base method.
+func (m *MockBackend) WitnessByNumber(ctx context.Context, number rpc.BlockNumber) (*stateless.Witness, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WitnessByNumber", ctx, number)
+	ret0, _ := ret[0].(*stateless.Witness)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WitnessByNumber indicates an expected call of WitnessByNumber.
+func (mr *MockBackendMockRecorder) WitnessByNumber(ctx, number any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WitnessByNumber", reflect.TypeOf((*MockBackend)(nil).WitnessByNumber), ctx, number)
+}
+
+// WitnessByNumberOrHash mocks base method.
+func (m *MockBackend) WitnessByNumberOrHash(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (*stateless.Witness, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WitnessByNumberOrHash", ctx, blockNrOrHash)
+	ret0, _ := ret[0].(*stateless.Witness)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WitnessByNumberOrHash indicates an expected call of WitnessByNumberOrHash.
+func (mr *MockBackendMockRecorder) WitnessByNumberOrHash(ctx, blockNrOrHash any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WitnessByNumberOrHash", reflect.TypeOf((*MockBackend)(nil).WitnessByNumberOrHash), ctx, blockNrOrHash)
+}

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -120,6 +120,9 @@ type Backend interface {
 	// Witness related APIs
 	GetWitnesses(ctx context.Context, originBlock uint64, totalBlocks uint64) ([]*stateless.Witness, error)
 	StoreWitness(ctx context.Context, blockHash common.Hash, witness *stateless.Witness) error
+	WitnessByNumber(ctx context.Context, number rpc.BlockNumber) (*stateless.Witness, error)
+	WitnessByHash(ctx context.Context, hash common.Hash) (*stateless.Witness, error)
+	WitnessByNumberOrHash(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (*stateless.Witness, error)
 
 	// Networking related APIs
 	PeerStats() interface{}

--- a/internal/ethapi/bor_api.go
+++ b/internal/ethapi/bor_api.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/stateless"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rpc"
 )
@@ -108,4 +109,19 @@ func (api *BorAPI) SendRawTransactionConditional(ctx context.Context, input hexu
 
 func (api *BorAPI) GetVoteOnHash(ctx context.Context, starBlockNr uint64, endBlockNr uint64, hash string, milestoneId string) (bool, error) {
 	return api.b.GetVoteOnHash(ctx, starBlockNr, endBlockNr, hash, milestoneId)
+}
+
+// GetWitnessByNumber returns the witness for the given block number.
+func (api *BorAPI) GetWitnessByNumber(ctx context.Context, number rpc.BlockNumber) (*stateless.Witness, error) {
+	return api.b.WitnessByNumber(ctx, number)
+}
+
+// GetWitnessByHash returns the witness for the given block hash.
+func (api *BorAPI) GetWitnessByHash(ctx context.Context, hash common.Hash) (*stateless.Witness, error) {
+	return api.b.WitnessByHash(ctx, hash)
+}
+
+// GetWitnessByBlockNumberOrHash returns the witness for the given block number or hash.
+func (api *BorAPI) GetWitnessByBlockNumberOrHash(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (*stateless.Witness, error) {
+	return api.b.WitnessByNumberOrHash(ctx, blockNrOrHash)
 }

--- a/internal/ethapi/transaction_args_test.go
+++ b/internal/ethapi/transaction_args_test.go
@@ -482,6 +482,19 @@ func (b *backendMock) GetWitnesses(ctx context.Context, startBlock uint64, endBl
 func (b *backendMock) StoreWitness(ctx context.Context, hash common.Hash, witness *stateless.Witness) error {
 	return nil
 }
+
+func (b *backendMock) WitnessByNumber(ctx context.Context, number rpc.BlockNumber) (*stateless.Witness, error) {
+	return nil, nil
+}
+
+func (b *backendMock) WitnessByHash(ctx context.Context, hash common.Hash) (*stateless.Witness, error) {
+	return nil, nil
+}
+
+func (b *backendMock) WitnessByNumberOrHash(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (*stateless.Witness, error) {
+	return nil, nil
+}
+
 func (b backendMock) SubscribePendingLogsEvent(ch chan<- []*types.Log) event.Subscription {
 	return nil
 }


### PR DESCRIPTION
# Description

Added 3 new RPC endpoints under the `bor` namespace:
- `bor_getWitnessByNumber`
- `bor_getWitnessByHash`
- `bor_getWitnessByBlockNumberOrHash`
