### PR TITLE
Purge whitelisted entries and bypass validation for incorrect milestone

### DIFF
--- a/core/rawdb/milestone.go
+++ b/core/rawdb/milestone.go
@@ -52,6 +52,27 @@ func (m *Milestone) block() (uint64, common.Hash) {
 	return m.Block, m.Hash
 }
 
+// PurgeWhitelistedEntriesFromDb removes all entries related to whitelisted checkpoint
+// and milestone from the database. It doesn't return any error back to the caller.
+func PurgeWhitelistedEntriesFromDb(db ethdb.KeyValueWriter) {
+	err := db.Delete(lastMilestone)
+	if err != nil {
+		log.Error("Error deleting last milestone entry", "err", err)
+	}
+	err = db.Delete(lockFieldKey)
+	if err != nil {
+		log.Error("Error deleting lock field entry", "err", err)
+	}
+	err = db.Delete(futureMilestoneKey)
+	if err != nil {
+		log.Error("Error deleting future milestone field entry", "err", err)
+	}
+	err = db.Delete(lastCheckpoint)
+	if err != nil {
+		log.Error("Error deleting last checkpoint entry", "err", err)
+	}
+}
+
 func ReadFinality[T BlockFinality[T]](db ethdb.KeyValueReader) (uint64, common.Hash, error) {
 	lastTV, key := getKey[T]()
 

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -40,6 +40,8 @@
 
 - [```peers status```](./peers_status.md)
 
+- [```purge-whitelisted-entries```](./purge-whitelisted-entries.md)
+
 - [```removedb```](./removedb.md)
 
 - [```server```](./server.md)

--- a/docs/cli/purge-whitelisted-entries.md
+++ b/docs/cli/purge-whitelisted-entries.md
@@ -1,0 +1,9 @@
+# Purge whitelisted entries
+
+The ```bor purge-whitelisted-entries``` command will remove locally whitelisted checkpoint and milestone entries from the database.
+
+## Options
+
+- ```datadir```: Path of the data directory to store information
+
+- ```keystore```: Path of the data directory to store keys

--- a/eth/downloader/whitelist/finality.go
+++ b/eth/downloader/whitelist/finality.go
@@ -35,7 +35,7 @@ func isIncorrectMilestone(number uint64, hash common.Hash) bool {
 		incorrectHash = common.HexToHash("7910a20918558674edb87759a2bb08b31af0de0e4eef0d8909be75af3591748f")
 	)
 	if number == incorrectEnd && hash == incorrectHash {
-		log.Info("Ignoring validating against incorrect milestone", "number", incorrectEnd, "hash", incorrectHash)
+		log.Debug("Ignoring validating against incorrect milestone", "number", incorrectEnd, "hash", incorrectHash)
 		return true
 	}
 	return false

--- a/eth/downloader/whitelist/finality.go
+++ b/eth/downloader/whitelist/finality.go
@@ -29,17 +29,32 @@ type finalityService interface {
 	Purge()
 }
 
+func isIncorrectMilestone(number uint64, hash common.Hash) bool {
+	var (
+		incorrectEnd  = uint64(76273070)
+		incorrectHash = common.HexToHash("7910a20918558674edb87759a2bb08b31af0de0e4eef0d8909be75af3591748f")
+	)
+	if number == incorrectEnd && hash == incorrectHash {
+		log.Info("Ignoring validating against incorrect milestone", "number", incorrectEnd, "hash", incorrectHash)
+		return true
+	}
+	return false
+}
+
 // IsValidPeer checks if the chain we're about to receive from a peer is valid or not
 // in terms of reorgs. We won't reorg beyond the last bor finality submitted to mainchain.
 func (f *finality[T]) IsValidPeer(fetchHeadersByNumber func(number uint64, amount int, skip int, reverse bool) ([]*types.Header, []common.Hash, error)) (bool, error) {
 	// We want to validate the chain by comparing the last finalized block
 	f.RLock()
-
 	doExist := f.doExist
 	number := f.Number
 	hash := f.Hash
-
 	f.RUnlock()
+
+	// Ignore validating against incorrect milestone
+	if isIncorrectMilestone(number, hash) {
+		return true, nil
+	}
 
 	return isValidPeer(fetchHeadersByNumber, doExist, number, hash)
 }
@@ -52,7 +67,18 @@ func (f *finality[T]) IsValidChain(currentHeader *types.Header, chain []*types.H
 		return false, nil
 	}
 
-	return isValidChain(currentHeader, chain, f.doExist, f.Number, f.Hash)
+	f.RLock()
+	doExist := f.doExist
+	number := f.Number
+	hash := f.Hash
+	f.RUnlock()
+
+	// Ignore validating against incorrect milestone
+	if isIncorrectMilestone(number, hash) {
+		return true, nil
+	}
+
+	return isValidChain(currentHeader, chain, doExist, number, hash)
 }
 
 // reportWhitelist logs the block number and hash if a new and unique entry is being inserted

--- a/eth/downloader/whitelist/milestone.go
+++ b/eth/downloader/whitelist/milestone.go
@@ -109,8 +109,12 @@ func (m *milestone) IsValidPeer(fetchHeadersByNumber func(number uint64, amount 
 		return true, nil
 	}
 
+	m.finality.RLock()
+	doExist := m.doExist
+	m.finality.RUnlock()
+
 	// Fork detection: Check if we have a local fork - if so, allow sync to recover
-	if m.blockchain != nil && m.doExist {
+	if m.blockchain != nil && doExist {
 		localHead := m.blockchain.CurrentBlock()
 		if localHead != nil && localHead.Number.Uint64() >= m.Number {
 			localBlock := m.blockchain.GetBlockByNumber(m.Number)

--- a/eth/downloader/whitelist/service.go
+++ b/eth/downloader/whitelist/service.go
@@ -25,18 +25,19 @@ type Service struct {
 }
 
 func NewService(db ethdb.Database) *Service {
+	// Fetch last whitelisted checkpoint entry from db. Ignore in case of error or if
+	// the whitelisted entry has empty hash.
 	var checkpointDoExist = true
-
 	checkpointNumber, checkpointHash, err := rawdb.ReadFinality[*rawdb.Checkpoint](db)
-
-	if err != nil {
+	if err != nil || checkpointHash == (common.Hash{}) {
 		checkpointDoExist = false
 	}
 
+	// Fetch last whitelisted milestone entry from db. Ignore in case of error or if
+	// the whitelisted entry has empty hash.
 	var milestoneDoExist = true
-
 	milestoneNumber, milestoneHash, err := rawdb.ReadFinality[*rawdb.Milestone](db)
-	if err != nil {
+	if err != nil || milestoneHash == (common.Hash{}) {
 		milestoneDoExist = false
 	}
 

--- a/eth/handler_bor.go
+++ b/eth/handler_bor.go
@@ -90,7 +90,7 @@ func isIncorrectMilestone(m *milestone.Milestone) bool {
 		incorrectHash  = common.HexToHash("7910a20918558674edb87759a2bb08b31af0de0e4eef0d8909be75af3591748f")
 	)
 	if m.StartBlock == incorrectStart && m.EndBlock == incorrectEnd && m.Hash == incorrectHash {
-		log.Info("Ignoring whitelisting incorrect milestone", "start", incorrectStart, "end", incorrectEnd, "hash", incorrectHash)
+		log.Debug("Ignoring whitelisting incorrect milestone", "start", incorrectStart, "end", incorrectEnd, "hash", incorrectHash)
 		return true
 	}
 	return false

--- a/eth/handler_bor.go
+++ b/eth/handler_bor.go
@@ -83,8 +83,26 @@ func (h *ethHandler) fetchWhitelistMilestone(ctx context.Context, bor *bor.Bor) 
 	return result, nil
 }
 
+func isIncorrectMilestone(m *milestone.Milestone) bool {
+	var (
+		incorrectStart = uint64(76273070)
+		incorrectEnd   = uint64(76273070)
+		incorrectHash  = common.HexToHash("7910a20918558674edb87759a2bb08b31af0de0e4eef0d8909be75af3591748f")
+	)
+	if m.StartBlock == incorrectStart && m.EndBlock == incorrectEnd && m.Hash == incorrectHash {
+		log.Info("Ignoring whitelisting incorrect milestone", "start", incorrectStart, "end", incorrectEnd, "hash", incorrectHash)
+		return true
+	}
+	return false
+}
+
 // handleMilestone verify and process the fetched milestone
 func (h *ethHandler) handleMilestone(ctx context.Context, eth *Ethereum, milestone *milestone.Milestone, verifier *borVerifier) error {
+	// Ignore processing the incorrect milestone
+	if isIncorrectMilestone(milestone) {
+		return nil
+	}
+
 	// Verify if the milestone fetched can be added to the local whitelist entry or not. If verified,
 	// the hash of the end block of the milestone is returned else appropriate error is returned.
 	_, err := verifier.verify(ctx, eth, h, milestone.StartBlock, milestone.EndBlock, milestone.Hash.String()[2:], false)

--- a/internal/cli/command.go
+++ b/internal/cli/command.go
@@ -206,6 +206,11 @@ func Commands() map[string]MarkDownCommandFactory {
 				Meta: meta,
 			}, nil
 		},
+		"purge-whitelisted-entries": func() (MarkDownCommand, error) {
+			return &PurgeWhitelistedEntriesCommand{
+				Meta: meta,
+			}, nil
+		},
 	}
 }
 

--- a/internal/cli/purge_whitelisted_entries.go
+++ b/internal/cli/purge_whitelisted_entries.go
@@ -1,0 +1,83 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/internal/cli/flagset"
+	"github.com/ethereum/go-ethereum/node"
+)
+
+type PurgeWhitelistedEntriesCommand struct {
+	*Meta
+
+	output string
+}
+
+func (c *PurgeWhitelistedEntriesCommand) MarkDown() string {
+	items := []string{
+		"# Purge whitelisted entries",
+		"The ```bor purge-whitelisted-entries``` command will remove locally whitelisted checkpoint and milestone entries from the database.",
+		c.Flags().MarkDown(),
+	}
+
+	return strings.Join(items, "\n\n")
+}
+
+// Help implements the cli.Command interface
+func (c *PurgeWhitelistedEntriesCommand) Help() string {
+	return `Usage: bor purge-whitelisted-entries
+
+  This command is used to purge the locally whitelisted checkpoint and milestone entries from the database.`
+}
+
+func (c *PurgeWhitelistedEntriesCommand) Flags() *flagset.Flagset {
+	flags := c.NewFlagSet("purge-whitelisted-entries")
+	return flags
+}
+
+// Synopsis implements the cli.Command interface
+func (c *PurgeWhitelistedEntriesCommand) Synopsis() string {
+	return "Purge the locally whitelisted checkpoint and milestone entries"
+}
+
+// Run implements the cli.Command interface
+func (c *PurgeWhitelistedEntriesCommand) Run(args []string) int {
+	flags := c.Flags()
+
+	if err := flags.Parse(args); err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	datadir := c.dataDir
+	if datadir == "" {
+		c.UI.Error("--datadir flag is required")
+		return 1
+	}
+
+	c.UI.Output("Starting to prune whitelisted entries. Opening database at path: " + datadir)
+	c.UI.Output("")
+
+	// Open the underlying key value database
+	node, err := node.New(&node.Config{
+		DataDir: datadir,
+	})
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Failed to create node: %v", err))
+		return 1
+	}
+	chaindb, err := node.OpenDatabase(datadir+"/bor/chaindata", 1024, 2000, "", false)
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Failed to open underlying key value database: %v", err))
+		return 1
+	}
+	c.UI.Output("Opened database at path: " + datadir)
+
+	// Purge all whitelisted entries from db
+	rawdb.PurgeWhitelistedEntriesFromDb(chaindb)
+
+	chaindb.Close()
+	return 0
+}

--- a/internal/cli/purge_whitelisted_entries.go
+++ b/internal/cli/purge_whitelisted_entries.go
@@ -58,7 +58,6 @@ func (c *PurgeWhitelistedEntriesCommand) Run(args []string) int {
 	}
 
 	c.UI.Output("Starting to prune whitelisted entries. Opening database at path: " + datadir)
-	c.UI.Output("")
 
 	// Open the underlying key value database
 	node, err := node.New(&node.Config{
@@ -77,6 +76,7 @@ func (c *PurgeWhitelistedEntriesCommand) Run(args []string) int {
 
 	// Purge all whitelisted entries from db
 	rawdb.PurgeWhitelistedEntriesFromDb(chaindb)
+	c.UI.Output("Finished purge attempt for local whitelisted entries")
 
 	chaindb.Close()
 	return 0


### PR DESCRIPTION
# Description

This PR
- Adds a new `bor purge-whitelisted-entries` sub command in cli which can purge all local whitelisted entries for checkpoint and milestone. 
- Adds a bypass logic to skip importing and validating against an incorrect milestone
- Skip loading milestones or checkpoints if local entry is corrupted (i.e. empty hash)

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Nodes audience

In case this PR includes changes that must be applied only to a subset of nodes, please specify how you handled it (e.g. by adding a flag with a default value...)

# Checklist

- [ ] I have added at least 2 reviewer or the whole pos-v1 team
- [ ] I have added sufficient documentation in code
- [ ] I will be resolving comments - if any - by pushing each fix in a separate commit and linking the commit hash in the comment reply
- [ ] Created a task in Jira and informed the team for implementation in Erigon client (if applicable)
- [ ] Includes RPC methods changes, and the Notion documentation has been updated

# Cross repository changes

- [ ] This PR requires changes to heimdall
    - In case link the PR here:
- [ ] This PR requires changes to matic-cli
    - In case link the PR here:

## Testing

- [ ] I have added unit tests
- [ ] I have added tests to CI
- [ ] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on amoy
- [ ] I have created new e2e tests into express-cli

### Manual tests

Please complete this section with the steps you performed if you ran manual tests for this functionality, otherwise delete it

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it
