### PR TITLE
Larger tx announce queue for trusted peers

### DIFF
--- a/eth/protocols/eth/broadcast.go
+++ b/eth/protocols/eth/broadcast.go
@@ -142,6 +142,12 @@ func (p *Peer) announceTransactions() {
 		fail   = make(chan error, 1) // Channel used to receive network error
 		failed bool                  // Flag whether a send failed, discard everything onward
 	)
+
+	queueLimit := maxQueuedTxAnns
+	if p.IsTrusted() || p.IsStatic() {
+		queueLimit = maxQueuedTxAnnsTrusted
+	}
+
 	for {
 		// If there's no in-flight announce running, check if a new one is needed
 		if done == nil && len(queue) > 0 {
@@ -197,9 +203,9 @@ func (p *Peer) announceTransactions() {
 			}
 			// New batch of transactions to be broadcast, queue them (with cap)
 			queue = append(queue, hashes...)
-			if len(queue) > maxQueuedTxAnns {
+			if len(queue) > queueLimit {
 				// Fancy copy and resize to ensure buffer doesn't grow indefinitely
-				queue = queue[:copy(queue, queue[len(queue)-maxQueuedTxAnns:])]
+				queue = queue[:copy(queue, queue[len(queue)-queueLimit:])]
 			}
 
 		case <-done:

--- a/eth/protocols/eth/peer.go
+++ b/eth/protocols/eth/peer.go
@@ -45,6 +45,9 @@ const (
 	// before dropping older announcements.
 	maxQueuedTxAnns = 4096
 
+	// maxQueuedTxAnnsTrusted is the maximum number of transaction announcements to queue up before dropping older announcements for trusted and static peers.
+	maxQueuedTxAnnsTrusted = 40960
+
 	// maxQueuedBlocks is the maximum number of block propagations to queue up before
 	// dropping broadcasts. There's not much point in queueing stale blocks, so a few
 	// that might cover uncles should be enough.


### PR DESCRIPTION
# Description

Allows the node to allocate more buffer (x10) for txn announcements for trusted and static peers. Larger queue reduces the possibility a transaction might get dropped by the node when there is a surge of txns in the network.

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

