### PR TITLE
Backfill StateSync Command

### DIFF
--- a/core/blockchain_reader.go
+++ b/core/blockchain_reader.go
@@ -29,6 +29,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/event"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/triedb"
@@ -251,14 +252,18 @@ func (bc *BlockChain) GetReceiptsByHash(hash common.Hash) types.Receipts {
 
 	number := rawdb.ReadHeaderNumber(bc.db, hash)
 	if number == nil {
+		log.Info("###_### No header number found!", "hash", hash, "number", number)
+
 		return nil
 	}
 	header := bc.GetHeader(hash, *number)
 	if header == nil {
+		log.Info("###_### No header found!", "hash", hash, "number", number)
 		return nil
 	}
 	receipts := rawdb.ReadReceipts(bc.db, hash, *number, header.Time, bc.chainConfig)
 	if receipts == nil {
+		log.Info("###_### No receipts found!", "hash", hash, "number", number)
 		return nil
 	}
 

--- a/core/blockchain_reader.go
+++ b/core/blockchain_reader.go
@@ -247,6 +247,8 @@ func (bc *BlockChain) GetBlocksFromHash(hash common.Hash, n int) (blocks []*type
 // GetReceiptsByHash retrieves the receipts for all transactions in a given block.
 func (bc *BlockChain) GetReceiptsByHash(hash common.Hash) types.Receipts {
 	if receipts, ok := bc.receiptsCache.Get(hash); ok {
+		log.Info("###_### Hitting cache!", "hash", hash)
+
 		return receipts
 	}
 

--- a/core/blockchain_reader.go
+++ b/core/blockchain_reader.go
@@ -29,7 +29,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/event"
-	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/triedb"
@@ -247,25 +246,19 @@ func (bc *BlockChain) GetBlocksFromHash(hash common.Hash, n int) (blocks []*type
 // GetReceiptsByHash retrieves the receipts for all transactions in a given block.
 func (bc *BlockChain) GetReceiptsByHash(hash common.Hash) types.Receipts {
 	if receipts, ok := bc.receiptsCache.Get(hash); ok {
-		log.Info("###_### Hitting cache!", "hash", hash)
-
 		return receipts
 	}
 
 	number := rawdb.ReadHeaderNumber(bc.db, hash)
 	if number == nil {
-		log.Info("###_### No header number found!", "hash", hash, "number", number)
-
 		return nil
 	}
 	header := bc.GetHeader(hash, *number)
 	if header == nil {
-		log.Info("###_### No header found!", "hash", hash, "number", number)
 		return nil
 	}
 	receipts := rawdb.ReadReceipts(bc.db, hash, *number, header.Time, bc.chainConfig)
 	if receipts == nil {
-		log.Info("###_### No receipts found!", "hash", hash, "number", number)
 		return nil
 	}
 

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -666,21 +666,15 @@ func HasReceipts(db ethdb.Reader, hash common.Hash, number uint64) bool {
 // ReadReceiptsRLP retrieves all the transaction receipts belonging to a block in RLP encoding.
 func ReadReceiptsRLP(db ethdb.Reader, hash common.Hash, number uint64) rlp.RawValue {
 	var data []byte
-	data, _ = db.Get(blockReceiptsKey(number, hash))
-	log.Info("###_### Forcing read from KV", "hash", hash, "number", number, "len(data)", len(data))
 
-	log.Info("###_### Reading Receipt RLP", "hash", hash, "number", number)
 	_ = db.ReadAncients(func(reader ethdb.AncientReaderOp) error {
 		// Check if the data is in ancients
 		if isCanon(reader, number, hash) {
 			data, _ = reader.Ancient(ChainFreezerReceiptTable, number)
-			log.Info("###_### Reading from Ancient", "hash", hash, "number", number)
 			return nil
 		}
 		// If not, try reading from leveldb
 		data, _ = db.Get(blockReceiptsKey(number, hash))
-		log.Info("###_### Reading from KV", "hash", hash, "number", number, "len(data)", len(data))
-
 		return nil
 	})
 

--- a/core/rawdb/accessors_chain.go
+++ b/core/rawdb/accessors_chain.go
@@ -666,15 +666,20 @@ func HasReceipts(db ethdb.Reader, hash common.Hash, number uint64) bool {
 // ReadReceiptsRLP retrieves all the transaction receipts belonging to a block in RLP encoding.
 func ReadReceiptsRLP(db ethdb.Reader, hash common.Hash, number uint64) rlp.RawValue {
 	var data []byte
+	data, _ = db.Get(blockReceiptsKey(number, hash))
+	log.Info("###_### Forcing read from KV", "hash", hash, "number", number, "len(data)", len(data))
 
+	log.Info("###_### Reading Receipt RLP", "hash", hash, "number", number)
 	_ = db.ReadAncients(func(reader ethdb.AncientReaderOp) error {
 		// Check if the data is in ancients
 		if isCanon(reader, number, hash) {
 			data, _ = reader.Ancient(ChainFreezerReceiptTable, number)
+			log.Info("###_### Reading from Ancient", "hash", hash, "number", number)
 			return nil
 		}
 		// If not, try reading from leveldb
 		data, _ = db.Get(blockReceiptsKey(number, hash))
+		log.Info("###_### Reading from KV", "hash", hash, "number", number, "len(data)", len(data))
 
 		return nil
 	})

--- a/core/rawdb/bor_receipt.go
+++ b/core/rawdb/bor_receipt.go
@@ -36,7 +36,7 @@ func ReadBorReceiptRLP(db ethdb.Reader, hash common.Hash, number uint64) rlp.Raw
 
 	// First, try to fetch from KV db
 	data, _ = db.Get(borReceiptKey(number, hash))
-	if data != nil {
+	if len(data) != 0 {
 		return data
 	}
 

--- a/docs/cli/backfill_statesync_txs.md
+++ b/docs/cli/backfill_statesync_txs.md
@@ -1,0 +1,9 @@
+# Backfill StateSync Txs
+
+The ```backfill-statesync-txs``` command receives a trusted file containing statesync txs and events from a time period and backfill it into the database. It walks over the block period checking any missing data and backfilling them. It writes just over KV database, which means the data which were supposed to already be on ancient will be now always at ancient.
+
+## Options
+
+- ```datadir```: Path of the data directory to store information
+
+- ```backfill-file```: Path of the file containing the backfill data

--- a/internal/cli/backfill_statesync_txs.go
+++ b/internal/cli/backfill_statesync_txs.go
@@ -9,12 +9,18 @@ import (
 	"fmt"
 	"math/big"
 	"os"
+	"runtime"
 	"sort"
 	"strings"
+	"sync"
+	"sync/atomic"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/internal/cli/flagset"
+	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/rlp"
 )
 
@@ -61,21 +67,6 @@ type WriteInstruction struct {
 	Key   string `json:"key"`
 	Value string `json:"value"`
 }
-
-// ----- Minimal RLP types to decode the stored receipt value -----
-//
-// The producer code encodes: types.ReceiptForStorage{ Status: ..., Logs: receiptJustLogs.Logs }
-// In go-ethereum, many derived fields on Log are tagged `rlp:"-"`, so they will *not* be present.
-// We only need Address, Topics, Data.
-
-type rlpLog struct {
-	Address common.Address
-	Topics  []common.Hash
-	Data    []byte
-	// All derived fields (TxHash, BlockHash, etc.) are rlp:"-" in geth and thus not encoded.
-}
-
-// ----- Constants / helpers -----
 
 var (
 	// Receipt key byte prefix: "matic-bor-receipt-"
@@ -176,12 +167,10 @@ func parseBlockNumberFromTxLookupValue(valHex string) (uint64, error) {
 	return n, nil
 }
 
-// ----- Validation -----
-
 type stateSyncPoint struct {
 	ID        uint64
 	BlockNum  uint64
-	ReceiptAt string // (optional) can keep the key for debugging
+	ReceiptAt string
 }
 
 type validationResult struct {
@@ -201,14 +190,14 @@ func (vr *validationResult) addWarn(format string, args ...any) {
 
 // ValidateBackfillFile runs the checks described in your request and prints a summary.
 // It returns a non-nil error if *invalid*.
-func ValidateBackfillFile(backfillFilePath string) error {
+func (c *BackFillStateSyncTxsEntriesCommand) validateBackfillFile(backfillFilePath string) ([]WriteInstruction, error) {
 	raw, err := os.ReadFile(backfillFilePath)
 	if err != nil {
-		return fmt.Errorf("read file: %w", err)
+		return nil, fmt.Errorf("read file: %w", err)
 	}
 	var writes []WriteInstruction
 	if err := json.Unmarshal(raw, &writes); err != nil {
-		return fmt.Errorf("parse JSON writes: %w", err)
+		return nil, fmt.Errorf("parse JSON writes: %w", err)
 	}
 
 	res := &validationResult{Valid: true}
@@ -329,37 +318,244 @@ func ValidateBackfillFile(backfillFilePath string) error {
 		}
 	}
 
-	// Summarize
 	if len(res.Errors) > 0 {
 		res.Valid = false
 	}
 
-	// ----- Output -----
-	fmt.Println("=== Backfill Validation Summary ===")
-	fmt.Printf("File: %s\n", backfillFilePath)
-	fmt.Printf("Valid: %v\n", res.Valid)
+	c.UI.Output("=== Backfill Validation Summary ===")
+	c.UI.Output(fmt.Sprintf("File: %s\n", backfillFilePath))
+	c.UI.Output(fmt.Sprintf("Valid: %v\n", res.Valid))
 	if len(res.Errors) > 0 {
-		fmt.Println("\nErrors:")
+		c.UI.Output("\nErrors:")
 		for _, e := range res.Errors {
-			fmt.Printf("  - %s\n", e)
+			c.UI.Output(fmt.Sprintf("  - %s\n", e))
 		}
 	}
 	if len(res.Warnings) > 0 {
-		fmt.Println("\nWarnings:")
+		c.UI.Output("\nWarnings:")
 		for _, w := range res.Warnings {
-			fmt.Printf("  - %s\n", w)
+			c.UI.Output(fmt.Sprintf("  - %s\n", w))
 		}
 	}
 	if len(allPoints) > 0 {
-		fmt.Printf("\nFirst state-sync:  ID=%d  Block=%d\n", res.FirstStateSyncID, res.FirstStateSyncBlock)
-		fmt.Printf("Last state-sync:   ID=%d  Block=%d\n", res.LastStateSyncID, res.LastStateSyncBlock)
+		c.UI.Output(fmt.Sprintf("\nFirst state-sync:  ID=%d  Block=%d\n", res.FirstStateSyncID, res.FirstStateSyncBlock))
+		c.UI.Output(fmt.Sprintf("Last state-sync:   ID=%d  Block=%d\n", res.LastStateSyncID, res.LastStateSyncBlock))
 	} else {
-		fmt.Println("\nNo state-sync logs discovered, so first/last not available.")
+		c.UI.Output("\nNo state-sync logs discovered, so first/last not available.")
 	}
 
 	if !res.Valid {
-		return fmt.Errorf("backfill validation: INVALID")
+		return nil, fmt.Errorf("backfill validation: INVALID")
 	}
+	return writes, nil
+}
+
+type putReq struct {
+	key []byte
+	val []byte
+}
+
+func incrementAndMaybeReportProgress(c *BackFillStateSyncTxsEntriesCommand, processed *int64, total int64) {
+	n := atomic.AddInt64(processed, 1)
+	if n%1000 == 0 || n == total {
+		c.UI.Output(fmt.Sprintf("Progress: %d/%d (%.2f%%)", n, total, 100*float64(n)/float64(total)))
+	}
+}
+
+// putMissingBackfill iterates over the writes in parallel, checks db presence, and batches missing puts.
+func (c *BackFillStateSyncTxsEntriesCommand) putMissingBackfill(chaindb ethdb.Database, writes []WriteInstruction) error {
+	batch := chaindb.NewBatch()
+
+	total := len(writes)
+
+	workers := runtime.GOMAXPROCS(0)
+	if workers > 8 {
+		workers = 8
+	}
+
+	jobs := make(chan WriteInstruction, workers*2)
+	puts := make(chan putReq, workers*4)
+	errCh := make(chan error, 1)
+
+	var processed int64
+	var checkedRcpt int64
+	var checkedLookup int64
+	var inserted int64
+	var skippedKnown int64
+	var skippedOther int64
+
+	var batchWG sync.WaitGroup
+	batchWG.Add(1)
+	go func() {
+		defer batchWG.Done()
+		for p := range puts {
+			if err := batch.Put(p.key, p.val); err != nil {
+				// First error wins
+				select {
+				case errCh <- fmt.Errorf("batch put failed: %w", err):
+				default:
+				}
+				return
+			}
+			atomic.AddInt64(&inserted, 1)
+		}
+	}()
+
+	// Worker pool
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer wg.Done()
+			for w := range jobs {
+				// Early exit if a hard error occurred (avoid wasted work)
+				select {
+				case e := <-errCh:
+					// put it back for others / caller, then stop
+					select {
+					case errCh <- e:
+					default:
+					}
+					return
+				default:
+				}
+
+				isReceipt, number, blockHash, err := parseReceiptKey(w.Key)
+				if err != nil {
+					c.UI.Output(fmt.Sprintf("WARN: %v (key=%s)", err, w.Key))
+					atomic.AddInt64(&skippedOther, 1)
+					incrementAndMaybeReportProgress(c, &processed, int64(total))
+					continue
+				}
+
+				if isReceipt {
+					atomic.AddInt64(&checkedRcpt, 1)
+
+					exists := rawdb.ReadBorReceiptRLP(chaindb, blockHash, number)
+					if len(exists) > 0 {
+						atomic.AddInt64(&skippedKnown, 1)
+						incrementAndMaybeReportProgress(c, &processed, int64(total))
+						continue
+					}
+
+					keyBytes, err := decodeHexString(w.Key)
+					if err != nil {
+						select {
+						case errCh <- fmt.Errorf("decode receipt key: %w", err):
+						default:
+						}
+						return
+					}
+					valBytes, err := decodeHexString(w.Value)
+					if err != nil {
+						select {
+						case errCh <- fmt.Errorf("decode receipt value: %w", err):
+						default:
+						}
+						return
+					}
+
+					select {
+					case puts <- putReq{key: keyBytes, val: valBytes}:
+					case e := <-errCh:
+						// propagate and return
+						select {
+						case errCh <- e:
+						default:
+						}
+						return
+					}
+
+					incrementAndMaybeReportProgress(c, &processed, int64(total))
+					continue
+				}
+
+				// txlookup path
+				txh, err := parseTxLookup(w.Key)
+				if err != nil {
+					c.UI.Output(fmt.Sprintf("WARN: cannot parse txlookup key (key=%s): %v", w.Key, err))
+					atomic.AddInt64(&skippedOther, 1)
+					incrementAndMaybeReportProgress(c, &processed, int64(total))
+					continue
+				}
+				atomic.AddInt64(&checkedLookup, 1)
+
+				if rawdb.ReadBorTxLookupEntry(chaindb, txh) != nil {
+					atomic.AddInt64(&skippedKnown, 1)
+					incrementAndMaybeReportProgress(c, &processed, int64(total))
+					continue
+				}
+
+				keyBytes, err := decodeHexString(w.Key)
+				if err != nil {
+					select {
+					case errCh <- fmt.Errorf("decode txlookup key: %w", err):
+					default:
+					}
+					return
+				}
+				valBytes, err := decodeHexString(w.Value)
+				if err != nil {
+					select {
+					case errCh <- fmt.Errorf("decode txlookup value: %w", err):
+					default:
+					}
+					return
+				}
+
+				select {
+				case puts <- putReq{key: keyBytes, val: valBytes}:
+				case e := <-errCh:
+					select {
+					case errCh <- e:
+					default:
+					}
+					return
+				}
+
+				incrementAndMaybeReportProgress(c, &processed, int64(total))
+			}
+		}()
+	}
+
+	go func() {
+		for _, w := range writes {
+			// If a hard error already happened, stop feeding.
+			select {
+			case e := <-errCh:
+				select {
+				case errCh <- e:
+				default:
+				}
+				close(jobs)
+				return
+			default:
+			}
+			jobs <- w
+		}
+		close(jobs)
+	}()
+
+	wg.Wait()
+	close(puts)
+	batchWG.Wait()
+
+	select {
+	case e := <-errCh:
+		return e
+	default:
+	}
+
+	// Final write
+	if err := batch.Write(); err != nil {
+		return fmt.Errorf("failed to write batch: %w", err)
+	}
+
+	c.UI.Output(fmt.Sprintf(
+		"Backfill summary: total=%d receipts_checked=%d txlookups_checked=%d inserted=%d already_present=%d skipped_other=%d",
+		total,
+		checkedRcpt, checkedLookup, inserted, skippedKnown, skippedOther,
+	))
 	return nil
 }
 
@@ -386,16 +582,27 @@ func (c *BackFillStateSyncTxsEntriesCommand) Run(args []string) int {
 
 	c.UI.Output("Starting to check the backfill file. Opening at path: " + backfillFilePath)
 
-	err := ValidateBackfillFile(backfillFilePath)
+	writes, err := c.validateBackfillFile(backfillFilePath)
 	if err != nil {
 		c.UI.Error("error while validating backfill file: " + err.Error())
 	}
 
-	// c.UI.Output(fmt.Sprintf("Backfill file is good and contains:\n- %d state sync transactions\n- %d state sync logs\n\nIn the block period of [%d,%d]", transactionCount, logsCount, blockStart, blockEnd))
+	c.UI.Output("Starting to check missing txs over database")
+	node, err := node.New(&node.Config{
+		DataDir: datadir,
+	})
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Failed to create node: %v", err))
+		return 1
+	}
+	chaindb, err := node.OpenDatabase(datadir+"/bor/chaindata", 1024, 2000, "", false)
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Failed to open underlying key value database: %v", err))
+		return 1
+	}
+	c.UI.Output("Opened database at path: " + datadir)
 
-	// c.UI.Output("Starting to check missing txs over database")
-
-	// c.UI.Output(fmt.Sprintf("Found:\n- %d missing state sync transactions\n- %d missing state sync logs", missingStateSyncTxsCount, missingStateSyncLogsCount))
+	c.putMissingBackfill(chaindb, writes)
 
 	return 0
 }

--- a/internal/cli/backfill_statesync_txs.go
+++ b/internal/cli/backfill_statesync_txs.go
@@ -1,0 +1,401 @@
+package cli
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/internal/cli/flagset"
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+type BackFillStateSyncTxsEntriesCommand struct {
+	*Meta
+	backfillFile string
+}
+
+func (c *BackFillStateSyncTxsEntriesCommand) MarkDown() string {
+	items := []string{
+		"# Backfill StateSync Txs",
+		"The ```backfill-statesync-txs``` command receives a trusted file containing statesync txs and events from a time period and backfill it into the database. It walks over the block period checking any missing data and backfilling them. It writes just over KV database, which means the data which were supposed to already be on ancient will be now always at ancient.",
+		c.Flags().MarkDown(),
+	}
+
+	return strings.Join(items, "\n\n")
+}
+
+// Help implements the cli.Command interface
+func (c *BackFillStateSyncTxsEntriesCommand) Help() string {
+	return `Usage: bor backfill-statesync-txs --datadir <path-to-datadir> --backfill-file <path-to-backfill-file>
+
+  This command receives a trusted file containing statesync txs and events from a time period and backfill it into the database. It walks over the block period checking any missing data and backfilling them. It writes just over KV database, which means the data which were supposed to already be on ancient will be now always at ancient.`
+}
+
+func (c *BackFillStateSyncTxsEntriesCommand) Flags() *flagset.Flagset {
+	flags := c.NewFlagSet("backfill-statesync-txs")
+
+	flags.StringFlag(&flagset.StringFlag{
+		Name:    "backfill-file",
+		Value:   &c.backfillFile,
+		Usage:   "Path of the file containing the backfill data",
+		Default: "",
+	})
+	return flags
+}
+
+// Synopsis implements the cli.Command interface
+func (c *BackFillStateSyncTxsEntriesCommand) Synopsis() string {
+	return "Backfill missing statesync txs based on a trusted file"
+}
+
+type WriteInstruction struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+// ----- Minimal RLP types to decode the stored receipt value -----
+//
+// The producer code encodes: types.ReceiptForStorage{ Status: ..., Logs: receiptJustLogs.Logs }
+// In go-ethereum, many derived fields on Log are tagged `rlp:"-"`, so they will *not* be present.
+// We only need Address, Topics, Data.
+
+type rlpLog struct {
+	Address common.Address
+	Topics  []common.Hash
+	Data    []byte
+	// All derived fields (TxHash, BlockHash, etc.) are rlp:"-" in geth and thus not encoded.
+}
+
+// ----- Constants / helpers -----
+
+var (
+	// Receipt key byte prefix: "matic-bor-receipt-"
+	borReceiptPrefix = []byte("matic-bor-receipt-")
+
+	// State sync topic[0]
+	stateSyncTopic0 = common.HexToHash("0x5a22725590b0a51c923940223f7458512164b1113359a735e86e7f27f44791ee")
+)
+
+// isHex0x checks and strips "0x" if present.
+func strip0x(s string) string {
+	if strings.HasPrefix(s, "0x") || strings.HasPrefix(s, "0X") {
+		return s[2:]
+	}
+	return s
+}
+
+// decodeHexString decodes a 0x-prefixed or plain hex string into bytes.
+func decodeHexString(s string) ([]byte, error) {
+	raw := strip0x(s)
+	if len(raw)%2 == 1 {
+		// tolerate odd-length hex by left-padding a zero nibble
+		raw = "0" + raw
+	}
+	return hex.DecodeString(raw)
+}
+
+// parseReceiptKey decodes the key and, if it is a receipt key, returns (true, blockNumber, blockHash, nil).
+// Receipt key layout (bytes): prefix ("matic-bor-receipt-") + [8 bytes big-endian block number] + [32 bytes block hash]
+func parseReceiptKey(keyHex string) (ok bool, blockNumber uint64, blockHash common.Hash, err error) {
+	b, err := decodeHexString(keyHex)
+	if err != nil {
+		return false, 0, common.Hash{}, fmt.Errorf("invalid hex key: %w", err)
+	}
+	if !bytes.HasPrefix(b, borReceiptPrefix) {
+		return false, 0, common.Hash{}, nil
+	}
+	suffix := b[len(borReceiptPrefix):]
+	if len(suffix) != 8+32 {
+		return false, 0, common.Hash{}, fmt.Errorf("receipt key: unexpected length (got %d, want %d)", len(suffix), 40)
+	}
+	blockNumber = binary.BigEndian.Uint64(suffix[:8])
+	copy(blockHash[:], suffix[8:])
+	return true, blockNumber, blockHash, nil
+}
+
+// parseTxLookup extracts the tx hash (best-effort) and assumes the layout: [prefix (unknown len)] + [32 bytes tx hash].
+func parseTxLookup(keyHex string) (txHash common.Hash, err error) {
+	b, err := decodeHexString(keyHex)
+	if err != nil {
+		return common.Hash{}, fmt.Errorf("invalid txlookup key hex: %w", err)
+	}
+	if len(b) < 32 {
+		return common.Hash{}, fmt.Errorf("txlookup key too short: %d", len(b))
+	}
+	copy(txHash[:], b[len(b)-32:])
+	return txHash, nil
+}
+
+// decodeReceiptValue decodes the RLP-encoded value into ReceiptForStorage.
+func decodeReceiptValue(valHex string) (*types.ReceiptForStorage, error) {
+	b, err := decodeHexString(valHex)
+	if err != nil {
+		return nil, fmt.Errorf("invalid receipt value hex: %w", err)
+	}
+	var out types.ReceiptForStorage
+	if err := rlp.DecodeBytes(b, &out); err != nil {
+		// Helpful hint: you can sanity-check what you’re decoding by hashing the bytes.
+		h := sha256.Sum256(b)
+		return nil, fmt.Errorf("failed to RLP-decode receipt (sha256=%x): %w", h[:8], err)
+	}
+	return &out, nil
+}
+
+// toBigIntFromTopicHash interprets a topic hash (32 bytes) as a big-endian integer.
+func toBigIntFromTopicHash(h common.Hash) *big.Int {
+	// Topics are 32-byte values; interpret as uint256.
+	return new(big.Int).SetBytes(h[:])
+}
+
+// parseBlockNumberFromTxLookupValue: txlookup value is "0x" + hex(blockNumberBytes) (big-endian).
+func parseBlockNumberFromTxLookupValue(valHex string) (uint64, error) {
+	b, err := decodeHexString(valHex)
+	if err != nil {
+		return 0, fmt.Errorf("invalid txlookup value hex: %w", err)
+	}
+	if len(b) == 0 {
+		return 0, fmt.Errorf("empty txlookup value")
+	}
+	if len(b) > 8 {
+		// Values may be shorter (no leading zeros); longer than 8 bytes would overflow uint64
+		return 0, fmt.Errorf("txlookup value too large for uint64: %d bytes", len(b))
+	}
+	var n uint64
+	for _, by := range b {
+		n = (n << 8) | uint64(by)
+	}
+	return n, nil
+}
+
+// ----- Validation -----
+
+type stateSyncPoint struct {
+	ID        uint64
+	BlockNum  uint64
+	ReceiptAt string // (optional) can keep the key for debugging
+}
+
+type validationResult struct {
+	Valid                                   bool
+	Errors                                  []string
+	Warnings                                []string
+	FirstStateSyncID, LastStateSyncID       uint64
+	FirstStateSyncBlock, LastStateSyncBlock uint64
+}
+
+func (vr *validationResult) addErr(format string, args ...any) {
+	vr.Errors = append(vr.Errors, fmt.Sprintf(format, args...))
+}
+func (vr *validationResult) addWarn(format string, args ...any) {
+	vr.Warnings = append(vr.Warnings, fmt.Sprintf(format, args...))
+}
+
+// ValidateBackfillFile runs the checks described in your request and prints a summary.
+// It returns a non-nil error if *invalid*.
+func ValidateBackfillFile(backfillFilePath string) error {
+	raw, err := os.ReadFile(backfillFilePath)
+	if err != nil {
+		return fmt.Errorf("read file: %w", err)
+	}
+	var writes []WriteInstruction
+	if err := json.Unmarshal(raw, &writes); err != nil {
+		return fmt.Errorf("parse JSON writes: %w", err)
+	}
+
+	res := &validationResult{Valid: true}
+
+	// Collect txlookup map: txHash -> blockNumber
+	txLookupBlockByHash := make(map[common.Hash]uint64)
+	// Also collect a set of blockNumbers that appear in any txlookup values, to satisfy the best-effort check.
+	txLookupBlocks := make(map[uint64]struct{})
+
+	// First pass: index txlookup entries
+	for _, w := range writes {
+		if ok, _, _, _ := parseReceiptKey(w.Key); ok {
+			continue // not a txlookup
+		}
+		// Treat as txlookup
+		txh, err := parseTxLookup(w.Key)
+		if err != nil {
+			res.addWarn("txlookup key parse failed (%s): %v", w.Key, err)
+			continue
+		}
+		bn, err := parseBlockNumberFromTxLookupValue(w.Value)
+		if err != nil {
+			res.addWarn("txlookup value parse failed for %s: %v", txh.Hex(), err)
+			continue
+		}
+		txLookupBlockByHash[txh] = bn
+		txLookupBlocks[bn] = struct{}{}
+	}
+
+	// For global consecutiveness: collect all state sync IDs across all receipts (and remember first/last blocks)
+	var allPoints []stateSyncPoint
+
+	// Second pass: validate receipt entries
+	for _, w := range writes {
+		ok, blockNum, _, err := parseReceiptKey(w.Key)
+		if err != nil {
+			res.addErr("receipt key parse error: %v", err)
+			continue
+		}
+		if !ok {
+			continue // not a receipt
+		}
+		// decode RLP value
+		rr, err := decodeReceiptValue(w.Value)
+		if err != nil {
+			res.addErr("receipt value decode failed (block %d): %v", blockNum, err)
+			continue
+		}
+
+		// 1) At least one state sync log
+		var stateSyncIDs []uint64
+		for _, lg := range rr.Logs {
+			if len(lg.Topics) == 0 {
+				continue
+			}
+			if lg.Topics[0] == stateSyncTopic0 {
+				// topics[1] must exist and encodes the state-sync ID
+				if len(lg.Topics) < 2 {
+					res.addErr("state-sync log missing topics[1] (block %d)", blockNum)
+					continue
+				}
+				idBI := toBigIntFromTopicHash(lg.Topics[1])
+				if !idBI.IsUint64() {
+					res.addErr("state-sync ID does not fit into uint64 (block %d)", blockNum)
+					continue
+				}
+				id := idBI.Uint64()
+				stateSyncIDs = append(stateSyncIDs, id)
+				allPoints = append(allPoints, stateSyncPoint{
+					ID:        id,
+					BlockNum:  blockNum,
+					ReceiptAt: w.Key,
+				})
+			}
+		}
+		if len(stateSyncIDs) == 0 {
+			res.addErr("receipt at block %d has no state-sync logs", blockNum)
+			continue
+		}
+
+		// 3) Best-effort txlookup presence: ensure that there exists *some* txlookup with this block number
+		if _, ok := txLookupBlocks[blockNum]; !ok {
+			// We can't derive the exact tx hash from the encoded logs (rlp:"-"), so we check block presence instead.
+			res.addErr("no txlookup entry found for block %d (best-effort check)", blockNum)
+		}
+	}
+
+	// 2) Global consecutiveness check for all state-sync IDs
+	if len(allPoints) == 0 {
+		res.addErr("no state-sync logs found in any receipt")
+	} else {
+		// Sort by ID, dedupe, and check gaps
+		sort.Slice(allPoints, func(i, j int) bool { return allPoints[i].ID < allPoints[j].ID })
+
+		// Track first/last ID and blocks
+		res.FirstStateSyncID = allPoints[0].ID
+		res.FirstStateSyncBlock = allPoints[0].BlockNum
+		res.LastStateSyncID = allPoints[len(allPoints)-1].ID
+		res.LastStateSyncBlock = allPoints[len(allPoints)-1].BlockNum
+
+		// Build unique ordered IDs and remember a canonical block for each
+		type idBlock struct {
+			id    uint64
+			block uint64
+		}
+		uniq := make([]idBlock, 0, len(allPoints))
+		for i := 0; i < len(allPoints); i++ {
+			if i == 0 || allPoints[i].ID != allPoints[i-1].ID {
+				uniq = append(uniq, idBlock{allPoints[i].ID, allPoints[i].BlockNum})
+			}
+		}
+		for i := 1; i < len(uniq); i++ {
+			prev, cur := uniq[i-1].id, uniq[i].id
+			if cur != prev+1 {
+				prevBlock, curBlock := uniq[i-1].block, uniq[i].block
+				res.addErr("state-sync IDs are not consecutive: %d (block: %d) -> %d (block %d) (gap detected)", prev, prevBlock, cur, curBlock)
+			}
+		}
+	}
+
+	// Summarize
+	if len(res.Errors) > 0 {
+		res.Valid = false
+	}
+
+	// ----- Output -----
+	fmt.Println("=== Backfill Validation Summary ===")
+	fmt.Printf("File: %s\n", backfillFilePath)
+	fmt.Printf("Valid: %v\n", res.Valid)
+	if len(res.Errors) > 0 {
+		fmt.Println("\nErrors:")
+		for _, e := range res.Errors {
+			fmt.Printf("  - %s\n", e)
+		}
+	}
+	if len(res.Warnings) > 0 {
+		fmt.Println("\nWarnings:")
+		for _, w := range res.Warnings {
+			fmt.Printf("  - %s\n", w)
+		}
+	}
+	if len(allPoints) > 0 {
+		fmt.Printf("\nFirst state-sync:  ID=%d  Block=%d\n", res.FirstStateSyncID, res.FirstStateSyncBlock)
+		fmt.Printf("Last state-sync:   ID=%d  Block=%d\n", res.LastStateSyncID, res.LastStateSyncBlock)
+	} else {
+		fmt.Println("\nNo state-sync logs discovered, so first/last not available.")
+	}
+
+	if !res.Valid {
+		return fmt.Errorf("backfill validation: INVALID")
+	}
+	return nil
+}
+
+// Run implements the cli.Command interface
+func (c *BackFillStateSyncTxsEntriesCommand) Run(args []string) int {
+	flags := c.Flags()
+
+	if err := flags.Parse(args); err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	datadir := c.dataDir
+	if datadir == "" {
+		c.UI.Error("--datadir flag is required")
+		return 1
+	}
+
+	backfillFilePath := c.backfillFile
+	if backfillFilePath == "" {
+		c.UI.Error("--backfill-file flag is required")
+		return 1
+	}
+
+	c.UI.Output("Starting to check the backfill file. Opening at path: " + backfillFilePath)
+
+	err := ValidateBackfillFile(backfillFilePath)
+	if err != nil {
+		c.UI.Error("error while validating backfill file: " + err.Error())
+	}
+
+	// c.UI.Output(fmt.Sprintf("Backfill file is good and contains:\n- %d state sync transactions\n- %d state sync logs\n\nIn the block period of [%d,%d]", transactionCount, logsCount, blockStart, blockEnd))
+
+	// c.UI.Output("Starting to check missing txs over database")
+
+	// c.UI.Output(fmt.Sprintf("Found:\n- %d missing state sync transactions\n- %d missing state sync logs", missingStateSyncTxsCount, missingStateSyncLogsCount))
+
+	return 0
+}

--- a/internal/cli/command.go
+++ b/internal/cli/command.go
@@ -211,6 +211,11 @@ func Commands() map[string]MarkDownCommandFactory {
 				Meta: meta,
 			}, nil
 		},
+		"backfill-statesync-txs": func() (MarkDownCommand, error) {
+			return &BackFillStateSyncTxsEntriesCommand{
+				Meta: meta,
+			}, nil
+		},
 	}
 }
 


### PR DESCRIPTION
# Description

The ```backfill-statesync-txs``` command receives a trusted file containing statesync txs and events from a time period and backfill it into the database. It walks over the block period checking any missing data and backfilling them. It writes just over KV database, which means the data which were supposed to already be on ancient will be now always at ancient.


# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes