### PR TITLE
Fix getSnapshotProposerSequence

### DIFF
--- a/consensus/bor/api.go
+++ b/consensus/bor/api.go
@@ -98,7 +98,7 @@ func (api *API) GetSnapshotProposerSequence(blockNrOrHash *rpc.BlockNumberOrHash
 		return BlockSigners{}, errUnknownBlock
 	}
 
-	snapNumber := rpc.BlockNumber(header.Number.Int64() - 1)
+	snapNumber := rpc.BlockNumber(header.Number.Int64())
 	snap, err := api.GetSnapshot(&snapNumber)
 
 	var difficulties = make(map[common.Address]uint64)
@@ -161,7 +161,7 @@ func (api *API) GetSnapshotProposer(blockNrOrHash *rpc.BlockNumberOrHash) (commo
 		return common.Address{}, errUnknownBlock
 	}
 
-	snapNumber := rpc.BlockNumber(header.Number.Int64() - 1)
+	snapNumber := rpc.BlockNumber(header.Number.Int64())
 	snap, err := api.GetSnapshot(&snapNumber)
 
 	if err != nil {


### PR DESCRIPTION
# Description

Use the correct block number for retrieving the snapshot. This is change is required because the behavior  of `snapshot()` in bor consensus had changed. Before, it was expecting the caller to pass the parent block of the target block, but now it is expecting the target block to be directly passed in.

Tested in a devnode. 

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes
