### PR TITLE
Drop a peer immediately on receiving empty witness

### DIFF
--- a/eth/fetcher/block_fetcher_race_test.go
+++ b/eth/fetcher/block_fetcher_race_test.go
@@ -2,7 +2,6 @@ package fetcher
 
 import (
 	"context"
-	"fmt"
 	"math/big"
 	"math/rand"
 	"sync"
@@ -393,15 +392,6 @@ func TestWitnessManagerConcurrentAccess(t *testing.T) {
 			default:
 			}
 
-			peer := "peer-penalty-" + randomString(5)
-
-			// Randomly penalize or check penalty status
-			if rand.Intn(2) == 0 {
-				manager.penalisePeer(peer)
-			} else {
-				_ = manager.HasFailedTooManyTimes(peer)
-			}
-
 			time.Sleep(time.Microsecond * time.Duration(rand.Intn(50)))
 		}
 	}()
@@ -569,23 +559,6 @@ func TestWitnessManagerStateConsistency(t *testing.T) {
 	if manager.isPending(hash) {
 		t.Error("Expected block to not be pending after forget")
 	}
-
-	// Test peer penalty consistency
-	peer := "test-peer"
-	manager.penalisePeer(peer)
-
-	if !manager.HasFailedTooManyTimes(peer) {
-		t.Error("Expected peer to be penalized")
-	}
-
-	// Manually expire penalty
-	manager.mu.Lock()
-	manager.peerPenalty[peer] = time.Now().Add(-time.Hour)
-	manager.mu.Unlock()
-
-	if manager.HasFailedTooManyTimes(peer) {
-		t.Error("Expected peer penalty to be expired")
-	}
 }
 
 // Helper function to generate random strings for peer IDs
@@ -690,127 +663,8 @@ func TestWitnessManagerMemoryLeaks(t *testing.T) {
 		// Mark as unavailable and then forget
 		manager.markWitnessUnavailable(hash)
 		manager.forget(hash)
-
-		// Penalize peer and then reset
-		peer := "test-peer-" + randomString(5)
-		manager.penalisePeer(peer)
-		manager.mu.Lock()
-		delete(manager.peerPenalty, peer)
-		delete(manager.failedWitnessAttempts, peer)
-		manager.mu.Unlock()
 	}
 
 	// Run cleanup
 	manager.cleanupUnavailableCache()
-
-	// Check map sizes
-	manager.mu.Lock()
-	totalMapSize := len(manager.pending) + len(manager.failedWitnessAttempts) +
-		len(manager.peerPenalty) + len(manager.witnessUnavailable)
-	manager.mu.Unlock()
-
-	if totalMapSize > 1000 {
-		t.Errorf("WitnessManager maps may be leaking memory, total size: %d", totalMapSize)
-	}
-}
-
-// TestWitnessManagerMapAccessRace specifically tests the race condition
-// that was fixed in handleWitnessFetchFailureExt where map access occurred
-// after the mutex was unlocked
-func TestWitnessManagerMapAccessRace(t *testing.T) {
-	quit := make(chan struct{})
-
-	dropPeer := peerDropFn(func(id string) {})
-	enqueueCh := make(chan *enqueueRequest, 100)
-	getBlock := blockRetrievalFn(func(hash common.Hash) *types.Block { return nil })
-	getHeader := HeaderRetrievalFn(func(hash common.Hash) *types.Header { return nil })
-	chainHeight := chainHeightFn(func() uint64 { return 100 })
-
-	manager := newWitnessManager(
-		quit,
-		dropPeer,
-		enqueueCh,
-		getBlock,
-		getHeader,
-		chainHeight,
-	)
-
-	// Start the manager
-	manager.start()
-	defer func() {
-		close(quit)
-		time.Sleep(10 * time.Millisecond) // Give the loop time to exit
-		manager.stop()
-	}()
-
-	// Create test data
-	hash := common.HexToHash("0x123")
-	peer1 := "test-peer-1"
-	peer2 := "test-peer-2"
-	err := fmt.Errorf("fetch failed")
-
-	// Run intensive concurrent operations that previously caused
-	// the race condition panic
-	var wg sync.WaitGroup
-	numGoroutines := 50
-	operationsPerGoroutine := 20
-
-	// Goroutine 1: Concurrent failure handling (the problematic function)
-	for i := 0; i < numGoroutines; i++ {
-		wg.Add(1)
-		go func(idx int) {
-			defer wg.Done()
-			peer := peer1
-			if idx%2 == 0 {
-				peer = peer2
-			}
-
-			for j := 0; j < operationsPerGoroutine; j++ {
-				// This call previously had a race condition
-				manager.handleWitnessFetchFailureExt(hash, peer, err, false)
-
-				// Add some variability to increase chance of race
-				if j%3 == 0 {
-					time.Sleep(time.Microsecond)
-				}
-			}
-		}(i)
-	}
-
-	// Goroutine 2: Concurrent penalty checks (accessing the same maps)
-	for i := 0; i < 10; i++ {
-		wg.Add(1)
-		go func(idx int) {
-			defer wg.Done()
-			peer := peer1
-			if idx%2 == 0 {
-				peer = peer2
-			}
-
-			for j := 0; j < operationsPerGoroutine*2; j++ {
-				// This accesses the same maps that the failure handler modifies
-				_ = manager.HasFailedTooManyTimes(peer)
-
-				if j%5 == 0 {
-					time.Sleep(time.Microsecond)
-				}
-			}
-		}(i)
-	}
-
-	wg.Wait()
-
-	// Verify that the maps are in a consistent state
-	manager.mu.Lock()
-	failures1 := manager.failedWitnessAttempts[peer1]
-	failures2 := manager.failedWitnessAttempts[peer2]
-	manager.mu.Unlock()
-
-	expectedTotal := numGoroutines/2*operationsPerGoroutine + (numGoroutines-numGoroutines/2)*operationsPerGoroutine
-	actualTotal := failures1 + failures2
-
-	if actualTotal != expectedTotal {
-		t.Errorf("Expected total failures %d, got %d (peer1: %d, peer2: %d)",
-			expectedTotal, actualTotal, failures1, failures2)
-	}
 }

--- a/eth/fetcher/witness_manager.go
+++ b/eth/fetcher/witness_manager.go
@@ -66,11 +66,9 @@ type witnessManager struct {
 	parentChainHeight chainHeightFn          // Retrieve chain height for distance checks
 
 	// Witness-specific state
-	pending               map[common.Hash]*witnessRequestState         // Blocks waiting for witness or actively fetching.
-	failedWitnessAttempts map[string]int                               // Tracks witness fetch failures per peer.
-	peerPenalty           map[string]time.Time                         // Tracks peers currently penalised until a given time.
-	witnessUnavailable    map[common.Hash]time.Time                    // Tracks hashes whose witnesses are known to be unavailable, with expiry times.
-	witnessCache          *ttlcache.Cache[common.Hash, *cachedWitness] // TTL cache of witnesses that arrived before their blocks
+	pending            map[common.Hash]*witnessRequestState         // Blocks waiting for witness or actively fetching.
+	witnessUnavailable map[common.Hash]time.Time                    // Tracks hashes whose witnesses are known to be unavailable, with expiry times.
+	witnessCache       *ttlcache.Cache[common.Hash, *cachedWitness] // TTL cache of witnesses that arrived before their blocks
 
 	// Communication channels (owned by witnessManager)
 	injectNeedWitnessCh chan *injectBlockNeedWitnessMsg // Injected blocks needing witness fetch
@@ -108,21 +106,19 @@ func newWitnessManager(
 	)
 
 	m := &witnessManager{
-		parentQuit:            parentQuit,
-		parentDropPeer:        parentDropPeer,
-		parentEnqueueCh:       parentEnqueueCh,
-		parentGetBlock:        parentGetBlock,
-		parentGetHeader:       parentGetHeader,
-		parentChainHeight:     parentChainHeight,
-		pending:               make(map[common.Hash]*witnessRequestState),
-		failedWitnessAttempts: make(map[string]int),
-		peerPenalty:           make(map[string]time.Time),
-		witnessUnavailable:    make(map[common.Hash]time.Time),
-		witnessCache:          witnessCache,
-		injectNeedWitnessCh:   make(chan *injectBlockNeedWitnessMsg, 10),
-		injectWitnessCh:       make(chan *injectedWitnessMsg, 10),
-		witnessTimer:          time.NewTimer(0),
-		pokeCh:                make(chan struct{}, 1),
+		parentQuit:          parentQuit,
+		parentDropPeer:      parentDropPeer,
+		parentEnqueueCh:     parentEnqueueCh,
+		parentGetBlock:      parentGetBlock,
+		parentGetHeader:     parentGetHeader,
+		parentChainHeight:   parentChainHeight,
+		pending:             make(map[common.Hash]*witnessRequestState),
+		witnessUnavailable:  make(map[common.Hash]time.Time),
+		witnessCache:        witnessCache,
+		injectNeedWitnessCh: make(chan *injectBlockNeedWitnessMsg, 10),
+		injectWitnessCh:     make(chan *injectedWitnessMsg, 10),
+		witnessTimer:        time.NewTimer(0),
+		pokeCh:              make(chan struct{}, 1),
 	}
 	// Clear the timer channel initially
 	if !m.witnessTimer.Stop() {
@@ -245,12 +241,6 @@ func (m *witnessManager) handleNeed(msg *injectBlockNeedWitnessMsg) {
 	// Check if witness is known to be unavailable
 	if m.isWitnessUnavailable(hash) {
 		log.Debug("[wm] Witness for injected block known to be unavailable, discarding", "hash", hash)
-		return
-	}
-
-	// Check if peer is currently penalised (do this outside of main lock to avoid deadlock)
-	if m.HasFailedTooManyTimes(msg.origin) {
-		log.Debug("[wm] Discarding injected block, peer is currently penalised for witness failures", "peer", msg.origin, "hash", hash)
 		return
 	}
 
@@ -470,23 +460,6 @@ func (m *witnessManager) tick() {
 
 	// Send out all block witness requests
 	for peer, hashAnnounceMap := range requests {
-		// Check if peer is currently penalised
-		if m.HasFailedTooManyTimes(peer) {
-			log.Debug("[wm] Skipping witness fetch batch, peer currently penalised", "peer", peer, "hashes", len(hashAnnounceMap))
-			m.mu.Lock()
-			if expiry, ok := m.peerPenalty[peer]; ok {
-				for h := range hashAnnounceMap {
-					if st := m.pending[h]; st != nil {
-						st.announce.time = expiry.Add(gatherSlack)
-					}
-				}
-			}
-			m.mu.Unlock()
-			// Reschedule timer based on the new future times.
-			m.rescheduleWitness()
-			continue // Skip this peer for now, hashes remain pending
-		}
-
 		// Collect hashes for logging
 		hashesToFetch := make([]common.Hash, 0, len(hashAnnounceMap))
 		for hash := range hashAnnounceMap {
@@ -501,6 +474,7 @@ func (m *witnessManager) tick() {
 		for hash, announce := range hashAnnounceMap {
 			// Ensure we have a valid announce and fetchWitness function
 			if announce == nil || announce.fetchWitness == nil {
+				m.handleWitnessFetchFailureExt(hash, "", errors.New("missing fetch configuration"), true)
 				continue
 			}
 
@@ -553,6 +527,7 @@ func (m *witnessManager) fetchWitness(peer string, hash common.Hash, announce *b
 	if _, exists := m.pending[hash]; !exists {
 		m.mu.Unlock()
 		log.Debug("[wm] Skipping witness fetch, block no longer pending", "peer", peer, "hash", hash)
+		m.handleWitnessFetchFailureExt(hash, "", fmt.Errorf("request initiation failed: %w", err), false)
 		req.Close()
 		return
 	}
@@ -566,6 +541,7 @@ func (m *witnessManager) fetchWitness(peer string, hash common.Hash, announce *b
 	case res := <-resCh:
 		if res == nil {
 			log.Debug("[wm] Witness response channel closed unexpectedly", "peer", peer, "hash", hash)
+			m.handleWitnessFetchFailureExt(hash, peer, errors.New("response channel closed"), false)
 			return
 		}
 		res.Done <- nil // Signal consumption
@@ -574,13 +550,13 @@ func (m *witnessManager) fetchWitness(peer string, hash common.Hash, announce *b
 		witness, ok := res.Res.([]*stateless.Witness)
 		if !ok {
 			log.Debug("[wm] Invalid witness response type received", "peer", peer, "hash", hash, "type", fmt.Sprintf("%T", res.Res))
-			m.parentDropPeer(peer)
+			m.handleWitnessFetchFailureExt(hash, peer, errors.New("invalid response type"), false)
 			return
 		}
 
 		if len(witness) == 0 {
 			log.Debug("[wm] Received empty witness response from peer", "peer", peer, "hash", hash)
-			m.parentDropPeer(peer)
+			m.handleWitnessFetchFailureExt(hash, peer, errors.New("empty witness response"), false)
 			return
 		}
 
@@ -589,7 +565,7 @@ func (m *witnessManager) fetchWitness(peer string, hash common.Hash, announce *b
 
 	case <-timeout.C:
 		log.Info("[wm] Witness fetch timed out for peer", "peer", peer, "hash", hash)
-		m.parentDropPeer(peer)
+		m.handleWitnessFetchFailureExt(hash, peer, errors.New("fetch timeout"), false)
 	case <-m.parentQuit:
 		log.Debug("[wm] Witness fetch cancelled due to shutdown", "peer", peer, "hash", hash)
 	}
@@ -688,16 +664,11 @@ func (m *witnessManager) handleWitnessFetchFailureExt(hash common.Hash, peer str
 			state.announce.time = time.Now().Add(fetchTimeout)
 		}
 	}
-	// Track peer failures (for metrics)
-	m.failedWitnessAttempts[peer]++
-	failures := m.failedWitnessAttempts[peer]
-
-	// Penalise peer with time-based window - do this under the same lock
-	until := time.Now().Add(witnessFailurePenalty)
-	m.peerPenalty[peer] = until
 	m.mu.Unlock()
 
-	log.Debug("[wm] Penalising peer for witness fetch failure", "peer", peer, "failures", failures, "penalty", witnessFailurePenalty, "until", until)
+	if peer != "" {
+		m.parentDropPeer(peer)
+	}
 
 	m.rescheduleWitness()
 }
@@ -727,11 +698,6 @@ func (m *witnessManager) safeEnqueue(op *blockOrHeaderInject) {
 	select {
 	case m.parentEnqueueCh <- req:
 		log.Debug("[wm] Successfully enqueued completed block+witness", "hash", hash, "origin", op.origin, "number", op.number())
-		// Reset failure count and penalty for the originating peer upon success.
-		m.mu.Lock()
-		delete(m.failedWitnessAttempts, op.origin)
-		delete(m.peerPenalty, op.origin)
-		m.mu.Unlock()
 	case <-m.parentQuit:
 		log.Debug("[wm] Failed to enqueue block+witness, fetcher shutting down", "hash", hash)
 		// Nothing more to do; the parent is quitting.
@@ -839,12 +805,6 @@ func (m *witnessManager) handleFilterResult(announce *blockAnnounce, block *type
 	}
 	m.mu.Unlock()
 
-	// Check if peer currently penalised
-	if m.HasFailedTooManyTimes(announce.origin) {
-		log.Debug("[wm] Discarding block from filter result, peer currently penalised", "peer", announce.origin, "hash", hash)
-		return
-	}
-
 	// Check if we have a cached witness for this block
 	if item := m.witnessCache.Get(hash); item != nil {
 		cached := item.Value()
@@ -903,12 +863,6 @@ func (m *witnessManager) checkCompleting(announce *blockAnnounce, block *types.B
 		}
 		m.mu.Unlock()
 
-		// Check if peer currently penalised
-		if m.HasFailedTooManyTimes(announce.origin) {
-			log.Debug("[wm] Discarding completed block, peer currently penalised", "peer", announce.origin, "hash", hash)
-			return
-		}
-
 		// Check if block known locally (might have been imported between header and body arrival)
 		if m.parentGetBlock(hash) != nil {
 			log.Debug("[wm] Completed block already known locally", "hash", hash)
@@ -937,30 +891,6 @@ func (m *witnessManager) checkCompleting(announce *blockAnnounce, block *types.B
 		// No witness needed, BlockFetcher should enqueue directly
 		log.Debug("[wm] Completed block does not require witness", "hash", hash)
 	}
-}
-
-func (m *witnessManager) HasFailedTooManyTimes(peer string) bool {
-	m.mu.Lock()
-	ts, ok := m.peerPenalty[peer]
-	if !ok {
-		m.mu.Unlock()
-		return false
-	}
-	if time.Now().After(ts) {
-		delete(m.peerPenalty, peer)
-		m.mu.Unlock()
-		return false
-	}
-	m.mu.Unlock()
-	return true
-}
-
-// penalisePeer marks a peer as penalised for witnessFailurePenalty duration.
-func (m *witnessManager) penalisePeer(peer string) {
-	until := time.Now().Add(witnessFailurePenalty)
-	m.mu.Lock()
-	m.peerPenalty[peer] = until
-	m.mu.Unlock()
 }
 
 var ErrNoWitnessPeerAvailable = errors.New("no peer with witness available") // Define a potential specific error

--- a/eth/fetcher/witness_manager.go
+++ b/eth/fetcher/witness_manager.go
@@ -501,9 +501,6 @@ func (m *witnessManager) tick() {
 		for hash, announce := range hashAnnounceMap {
 			// Ensure we have a valid announce and fetchWitness function
 			if announce == nil || announce.fetchWitness == nil {
-				log.Debug("[wm] Missing announce or fetchWitness for witness request", "peer", peer, "hash", hash)
-				// Hard failure: remove from pending so we don't spin forever
-				m.handleWitnessFetchFailureExt(hash, peer, errors.New("missing fetch configuration"), true)
 				continue
 			}
 
@@ -546,10 +543,10 @@ func (m *witnessManager) fetchWitness(peer string, hash common.Hash, announce *b
 		}
 		m.mu.Unlock()
 
-		// Penalize the peer for other initiation failures
-		m.handleWitnessFetchFailureExt(hash, peer, fmt.Errorf("request initiation failed: %w", err), false)
 		return
 	}
+
+	peer = req.Peer
 
 	// Check if still pending after successful request creation
 	m.mu.Lock()
@@ -569,7 +566,6 @@ func (m *witnessManager) fetchWitness(peer string, hash common.Hash, announce *b
 	case res := <-resCh:
 		if res == nil {
 			log.Debug("[wm] Witness response channel closed unexpectedly", "peer", peer, "hash", hash)
-			m.handleWitnessFetchFailureExt(hash, peer, errors.New("response channel closed"), false)
 			return
 		}
 		res.Done <- nil // Signal consumption
@@ -578,13 +574,13 @@ func (m *witnessManager) fetchWitness(peer string, hash common.Hash, announce *b
 		witness, ok := res.Res.([]*stateless.Witness)
 		if !ok {
 			log.Debug("[wm] Invalid witness response type received", "peer", peer, "hash", hash, "type", fmt.Sprintf("%T", res.Res))
-			m.handleWitnessFetchFailureExt(hash, peer, errors.New("invalid response type"), false)
+			m.parentDropPeer(peer)
 			return
 		}
 
 		if len(witness) == 0 {
 			log.Debug("[wm] Received empty witness response from peer", "peer", peer, "hash", hash)
-			m.handleWitnessFetchFailureExt(hash, peer, errors.New("empty witness response"), false)
+			m.parentDropPeer(peer)
 			return
 		}
 
@@ -593,10 +589,9 @@ func (m *witnessManager) fetchWitness(peer string, hash common.Hash, announce *b
 
 	case <-timeout.C:
 		log.Info("[wm] Witness fetch timed out for peer", "peer", peer, "hash", hash)
-		m.handleWitnessFetchFailureExt(hash, peer, errors.New("fetch timeout"), false)
+		m.parentDropPeer(peer)
 	case <-m.parentQuit:
 		log.Debug("[wm] Witness fetch cancelled due to shutdown", "peer", peer, "hash", hash)
-		// Don't penalize peer for shutdown
 	}
 }
 

--- a/eth/fetcher/witness_manager.go
+++ b/eth/fetcher/witness_manager.go
@@ -28,14 +28,6 @@ const (
 	// witness for a block hash before giving up and marking it unavailable.
 	maxWitnessFetchRetries = 10
 
-	// witnessFailurePenalty defines how long a peer is considered "penalised"
-	// after a witness-related failure. While a peer is penalised, the
-	// witnessManager will not initiate new witness requests for that peer and
-	// the BlockFetcher will also ignore its announcements that require a
-	// witness. Once the penalty window elapses the peer is automatically
-	// eligible again.
-	witnessFailurePenalty = 5 * time.Second
-
 	witnessCacheSize = 10
 	witnessCacheTTL  = 2 * time.Minute
 )

--- a/eth/fetcher/witness_manager.go
+++ b/eth/fetcher/witness_manager.go
@@ -517,7 +517,12 @@ func (m *witnessManager) fetchWitness(peer string, hash common.Hash, announce *b
 		}
 		m.mu.Unlock()
 
-		return
+		if req != nil {
+			peer = req.Peer
+		} else {
+			peer = ""
+		}
+		m.handleWitnessFetchFailureExt(hash, peer, fmt.Errorf("request initiation failed: %w", err), false)
 	}
 
 	peer = req.Peer

--- a/eth/fetcher/witness_manager_test.go
+++ b/eth/fetcher/witness_manager_test.go
@@ -25,10 +25,9 @@ func createTestBlock(number uint64) *types.Block {
 }
 
 func createTestWitnessForBlock(block *types.Block) *stateless.Witness {
-	// Create a witness with the same header as the block
 	witness, err := stateless.NewWitness(block.Header(), nil)
 	if err != nil {
-		panic(err) // This shouldn't happen in tests
+		panic(err)
 	}
 	return witness
 }
@@ -43,84 +42,97 @@ func createTestBlockAnnounce(origin string, block *types.Block, fetchWitness wit
 	}
 }
 
-// TestWitnessManagerCreation tests the creation and basic setup of witnessManager
-func TestWitnessManagerCreation(t *testing.T) {
-	quit := make(chan struct{})
-	defer close(quit)
+// Test setup helper
+type testWitnessManager struct {
+	manager      *witnessManager
+	quit         chan struct{}
+	enqueueCh    chan *enqueueRequest
+	droppedPeers []string
+	mu           sync.Mutex
+}
 
-	dropPeer := peerDropFn(func(id string) {})
+func newTestWitnessManager() *testWitnessManager {
+	quit := make(chan struct{})
 	enqueueCh := make(chan *enqueueRequest, 10)
+
+	tw := &testWitnessManager{
+		quit:      quit,
+		enqueueCh: enqueueCh,
+	}
+
+	dropPeer := peerDropFn(func(id string) {
+		tw.mu.Lock()
+		tw.droppedPeers = append(tw.droppedPeers, id)
+		tw.mu.Unlock()
+	})
+
 	getBlock := blockRetrievalFn(func(hash common.Hash) *types.Block { return nil })
 	getHeader := HeaderRetrievalFn(func(hash common.Hash) *types.Header { return nil })
 	chainHeight := chainHeightFn(func() uint64 { return 100 })
 
-	manager := newWitnessManager(
-		quit,
-		dropPeer,
-		enqueueCh,
-		getBlock,
-		getHeader,
-		chainHeight,
-	)
+	tw.manager = newWitnessManager(quit, dropPeer, enqueueCh, getBlock, getHeader, chainHeight)
+	return tw
+}
 
-	if manager == nil {
+func (tw *testWitnessManager) Close() {
+	close(tw.quit)
+}
+
+func (tw *testWitnessManager) DroppedPeers() []string {
+	tw.mu.Lock()
+	defer tw.mu.Unlock()
+	result := make([]string, len(tw.droppedPeers))
+	copy(result, tw.droppedPeers)
+	return result
+}
+
+func (tw *testWitnessManager) PendingCount() int {
+	tw.manager.mu.Lock()
+	defer tw.manager.mu.Unlock()
+	return len(tw.manager.pending)
+}
+
+// TestWitnessManagerCreation tests the creation and basic setup of witnessManager
+func TestWitnessManagerCreation(t *testing.T) {
+	tw := newTestWitnessManager()
+	defer tw.Close()
+
+	if tw.manager == nil {
 		t.Fatal("Expected witnessManager to be created")
 	}
 
 	// Check initial state
-	if len(manager.pending) != 0 {
-		t.Errorf("Expected empty pending map, got %d items", len(manager.pending))
+	if tw.PendingCount() != 0 {
+		t.Errorf("Expected empty pending map, got %d items", tw.PendingCount())
 	}
 
-	if len(manager.failedWitnessAttempts) != 0 {
-		t.Errorf("Expected empty failedWitnessAttempts map, got %d items", len(manager.failedWitnessAttempts))
-	}
-
-	if len(manager.peerPenalty) != 0 {
-		t.Errorf("Expected empty peerPenalty map, got %d items", len(manager.peerPenalty))
-	}
-
-	if manager.witnessTimer == nil {
+	if tw.manager.witnessTimer == nil {
 		t.Error("Expected witnessTimer to be initialized")
 	}
 
 	// Test channels are created with proper buffering
-	if cap(manager.injectNeedWitnessCh) != 10 {
-		t.Errorf("Expected injectNeedWitnessCh buffer size 10, got %d", cap(manager.injectNeedWitnessCh))
+	if cap(tw.manager.injectNeedWitnessCh) != 10 {
+		t.Errorf("Expected injectNeedWitnessCh buffer size 10, got %d", cap(tw.manager.injectNeedWitnessCh))
 	}
 
-	if cap(manager.injectWitnessCh) != 10 {
-		t.Errorf("Expected injectWitnessCh buffer size 10, got %d", cap(manager.injectWitnessCh))
+	if cap(tw.manager.injectWitnessCh) != 10 {
+		t.Errorf("Expected injectWitnessCh buffer size 10, got %d", cap(tw.manager.injectWitnessCh))
 	}
 }
 
 // TestWitnessManagerLifecycle tests start and stop functionality
 func TestWitnessManagerLifecycle(t *testing.T) {
-	quit := make(chan struct{})
-	dropPeer := peerDropFn(func(id string) {})
-	enqueueCh := make(chan *enqueueRequest, 10)
-	getBlock := blockRetrievalFn(func(hash common.Hash) *types.Block { return nil })
-	getHeader := HeaderRetrievalFn(func(hash common.Hash) *types.Header { return nil })
-	chainHeight := chainHeightFn(func() uint64 { return 100 })
-
-	manager := newWitnessManager(
-		quit,
-		dropPeer,
-		enqueueCh,
-		getBlock,
-		getHeader,
-		chainHeight,
-	)
+	tw := newTestWitnessManager()
+	defer tw.Close()
 
 	// Start the manager
-	manager.start()
+	tw.manager.start()
 
 	// Give it a moment to start
 	time.Sleep(10 * time.Millisecond)
 
 	// Stop the manager
-	manager.stop()
-	close(quit)
+	tw.manager.stop()
 
 	// Give it a moment to stop
 	time.Sleep(10 * time.Millisecond)
@@ -128,23 +140,8 @@ func TestWitnessManagerLifecycle(t *testing.T) {
 
 // TestHandleNeed tests processing of blocks needing witnesses
 func TestHandleNeed(t *testing.T) {
-	quit := make(chan struct{})
-	defer close(quit)
-
-	dropPeer := peerDropFn(func(id string) {})
-	enqueueCh := make(chan *enqueueRequest, 10)
-	getBlock := blockRetrievalFn(func(hash common.Hash) *types.Block { return nil })
-	getHeader := HeaderRetrievalFn(func(hash common.Hash) *types.Header { return nil })
-	chainHeight := chainHeightFn(func() uint64 { return 100 })
-
-	manager := newWitnessManager(
-		quit,
-		dropPeer,
-		enqueueCh,
-		getBlock,
-		getHeader,
-		chainHeight,
-	)
+	tw := newTestWitnessManager()
+	defer tw.Close()
 
 	block := createTestBlock(101)
 	fetchWitness := func(hash common.Hash, responseCh chan *eth.Response) (*eth.Request, error) {
@@ -158,20 +155,16 @@ func TestHandleNeed(t *testing.T) {
 	}
 
 	// Test successful handling
-	manager.handleNeed(msg)
+	tw.manager.handleNeed(msg)
 
 	// Check that block was added to pending
-	if !manager.isPending(block.Hash()) {
+	if !tw.manager.isPending(block.Hash()) {
 		t.Error("Expected block to be pending after handleNeed")
 	}
 
 	// Check pending count
-	manager.mu.Lock()
-	pendingCount := len(manager.pending)
-	manager.mu.Unlock()
-
-	if pendingCount != 1 {
-		t.Errorf("Expected 1 pending request, got %d", pendingCount)
+	if tw.PendingCount() != 1 {
+		t.Errorf("Expected 1 pending request, got %d", tw.PendingCount())
 	}
 }
 
@@ -404,52 +397,6 @@ func TestWitnessUnavailable(t *testing.T) {
 	_ = originalTimeout
 }
 
-// TestPeerPenalty tests peer penalty system
-func TestPeerPenalty(t *testing.T) {
-	quit := make(chan struct{})
-	defer close(quit)
-
-	dropPeer := peerDropFn(func(id string) {})
-	enqueueCh := make(chan *enqueueRequest, 10)
-	getBlock := blockRetrievalFn(func(hash common.Hash) *types.Block { return nil })
-	getHeader := HeaderRetrievalFn(func(hash common.Hash) *types.Header { return nil })
-	chainHeight := chainHeightFn(func() uint64 { return 100 })
-
-	manager := newWitnessManager(
-		quit,
-		dropPeer,
-		enqueueCh,
-		getBlock,
-		getHeader,
-		chainHeight,
-	)
-
-	peer := "test-peer"
-
-	// Initially should not have failed too many times
-	if manager.HasFailedTooManyTimes(peer) {
-		t.Error("Expected peer to not be penalised initially")
-	}
-
-	// Penalise the peer
-	manager.penalisePeer(peer)
-
-	// Should now be penalised
-	if !manager.HasFailedTooManyTimes(peer) {
-		t.Error("Expected peer to be penalised after penalisePeer call")
-	}
-
-	// Manually expire the penalty for testing
-	manager.mu.Lock()
-	manager.peerPenalty[peer] = time.Now().Add(-time.Minute)
-	manager.mu.Unlock()
-
-	// Should no longer be penalised
-	if manager.HasFailedTooManyTimes(peer) {
-		t.Error("Expected peer to not be penalised after penalty expiry")
-	}
-}
-
 // TestForget tests cleanup of pending state
 func TestForget(t *testing.T) {
 	quit := make(chan struct{})
@@ -575,7 +522,11 @@ func TestWitnessFetchFailure(t *testing.T) {
 	quit := make(chan struct{})
 	defer close(quit)
 
-	dropPeer := peerDropFn(func(id string) {})
+	droppedPeer := ""
+
+	dropPeer := peerDropFn(func(id string) {
+		droppedPeer = id
+	})
 	enqueueCh := make(chan *enqueueRequest, 10)
 	getBlock := blockRetrievalFn(func(hash common.Hash) *types.Block { return nil })
 	getHeader := HeaderRetrievalFn(func(hash common.Hash) *types.Header { return nil })
@@ -594,21 +545,89 @@ func TestWitnessFetchFailure(t *testing.T) {
 	peer := "test-peer"
 	err := errors.New("fetch failed")
 
-	// Test soft failure (keep pending for retry)
+	// Test soft failure (keep pending for retry) - peer should still be dropped
 	manager.handleWitnessFetchFailureExt(hash, peer, err, false)
 
-	// Check that peer failure count increased
-	manager.mu.Lock()
-	failureCount := manager.failedWitnessAttempts[peer]
-	manager.mu.Unlock()
+	if droppedPeer != peer {
+		t.Errorf("Expected peer to be dropped on soft failure, got %s", droppedPeer)
+	}
+}
 
-	if failureCount != 1 {
-		t.Errorf("Expected failure count 1, got %d", failureCount)
+// TestWitnessFetchFailureAlwaysDropsPeer tests that handleWitnessFetchFailureExt
+// always drops the peer regardless of removePending flag
+func TestWitnessFetchFailureAlwaysDropsPeer(t *testing.T) {
+	tw := newTestWitnessManager()
+	defer tw.Close()
+
+	hash := common.HexToHash("0x123")
+	peer1 := "test-peer-1"
+	peer2 := "test-peer-2"
+	err := errors.New("fetch failed")
+
+	// Add a pending request to test removal behavior
+	block := createTestBlock(101)
+	state := &witnessRequestState{
+		op: &blockOrHeaderInject{
+			origin: peer1,
+			block:  block,
+		},
+		announce: &blockAnnounce{
+			origin: peer1,
+			hash:   hash,
+			number: 101,
+			time:   time.Now(),
+			fetchWitness: func(hash common.Hash, responseCh chan *eth.Response) (*eth.Request, error) {
+				return nil, nil
+			},
+		},
+		retries: 0,
 	}
 
-	// Check that peer is penalised
-	if !manager.HasFailedTooManyTimes(peer) {
-		t.Error("Expected peer to be penalised after failure")
+	tw.manager.mu.Lock()
+	tw.manager.pending[hash] = state
+	tw.manager.mu.Unlock()
+
+	// Test soft failure (removePending = false) - peer should be dropped
+	tw.manager.handleWitnessFetchFailureExt(hash, peer1, err, false)
+
+	droppedPeers := tw.DroppedPeers()
+	if len(droppedPeers) != 1 || droppedPeers[0] != peer1 {
+		t.Errorf("Expected peer1 to be dropped on soft failure, got %v", droppedPeers)
+	}
+
+	// Verify pending request was NOT removed (soft failure)
+	if !tw.manager.isPending(hash) {
+		t.Error("Expected pending request to remain after soft failure")
+	}
+
+	// Test hard failure (removePending = true) - peer should also be dropped
+	tw.manager.handleWitnessFetchFailureExt(hash, peer2, err, true)
+
+	droppedPeers = tw.DroppedPeers()
+	if len(droppedPeers) != 2 || droppedPeers[1] != peer2 {
+		t.Errorf("Expected peer2 to be dropped on hard failure, got %v", droppedPeers)
+	}
+
+	// Verify pending request was removed (hard failure)
+	if tw.manager.isPending(hash) {
+		t.Error("Expected pending request to be removed after hard failure")
+	}
+}
+
+// TestWitnessFetchFailureEmptyPeer tests that no peer is dropped when peer string is empty
+func TestWitnessFetchFailureEmptyPeer(t *testing.T) {
+	tw := newTestWitnessManager()
+	defer tw.Close()
+
+	hash := common.HexToHash("0x123")
+	err := errors.New("fetch failed")
+
+	// Test with empty peer string - no peer should be dropped
+	tw.manager.handleWitnessFetchFailureExt(hash, "", err, false)
+
+	droppedPeers := tw.DroppedPeers()
+	if len(droppedPeers) != 0 {
+		t.Errorf("Expected no peer to be dropped when peer string is empty, got %v", droppedPeers)
 	}
 }
 
@@ -1264,50 +1283,6 @@ func TestSafeEnqueueChannelClosed(t *testing.T) {
 	// Should not panic and should use the quit channel path
 }
 
-// TestHandleNeedPenalizedPeer tests handleNeed with penalized peer
-func TestHandleNeedPenalizedPeer(t *testing.T) {
-	quit := make(chan struct{})
-	defer close(quit)
-
-	dropPeer := peerDropFn(func(id string) {})
-	enqueueCh := make(chan *enqueueRequest, 10)
-	getBlock := blockRetrievalFn(func(hash common.Hash) *types.Block { return nil })
-	getHeader := HeaderRetrievalFn(func(hash common.Hash) *types.Header { return nil })
-	chainHeight := chainHeightFn(func() uint64 { return 100 })
-
-	manager := newWitnessManager(
-		quit,
-		dropPeer,
-		enqueueCh,
-		getBlock,
-		getHeader,
-		chainHeight,
-	)
-
-	// Penalize peer first
-	peer := "test-peer"
-	manager.penalisePeer(peer)
-
-	block := createTestBlock(101)
-	fetchWitness := func(hash common.Hash, responseCh chan *eth.Response) (*eth.Request, error) {
-		return nil, nil
-	}
-
-	msg := &injectBlockNeedWitnessMsg{
-		origin:       peer,
-		block:        block,
-		fetchWitness: fetchWitness,
-	}
-
-	// Test handleNeed with penalized peer - should be ignored
-	manager.handleNeed(msg)
-
-	// Check that no pending requests were created
-	if manager.isPending(block.Hash()) {
-		t.Error("Expected request to be ignored for penalized peer")
-	}
-}
-
 // TestHandleNeedDistanceCheck tests handleNeed with distance check
 func TestHandleNeedDistanceCheck(t *testing.T) {
 	quit := make(chan struct{})
@@ -1701,46 +1676,6 @@ func TestHandleFilterResultDuplicate(t *testing.T) {
 	}
 }
 
-// TestHandleFilterResultPenalizedPeer tests filter result with penalized peer
-func TestHandleFilterResultPenalizedPeer(t *testing.T) {
-	quit := make(chan struct{})
-	defer close(quit)
-
-	dropPeer := peerDropFn(func(id string) {})
-	enqueueCh := make(chan *enqueueRequest, 10)
-	getBlock := blockRetrievalFn(func(hash common.Hash) *types.Block { return nil })
-	getHeader := HeaderRetrievalFn(func(hash common.Hash) *types.Header { return nil })
-	chainHeight := chainHeightFn(func() uint64 { return 100 })
-
-	manager := newWitnessManager(
-		quit,
-		dropPeer,
-		enqueueCh,
-		getBlock,
-		getHeader,
-		chainHeight,
-	)
-
-	peer := "test-peer"
-	// Penalize peer first
-	manager.penalisePeer(peer)
-
-	block := createTestBlock(101)
-	fetchWitness := func(hash common.Hash, responseCh chan *eth.Response) (*eth.Request, error) {
-		return nil, nil
-	}
-
-	announce := createTestBlockAnnounce(peer, block, fetchWitness)
-
-	// Handle filter result with penalized peer
-	manager.handleFilterResult(announce, block)
-
-	// Check that block was NOT added to pending
-	if manager.isPending(block.Hash()) {
-		t.Error("Expected block from penalized peer to be discarded")
-	}
-}
-
 // TestCheckCompletingWitnessUnavailable tests checkCompleting with unavailable witness
 func TestCheckCompletingWitnessUnavailable(t *testing.T) {
 	quit := make(chan struct{})
@@ -1863,46 +1798,6 @@ func TestCheckCompletingKnownBlock(t *testing.T) {
 	// Check that block was NOT added to pending
 	if manager.isPending(block.Hash()) {
 		t.Error("Expected known block to be ignored")
-	}
-}
-
-// TestCheckCompletingPenalizedPeer tests checkCompleting with penalized peer
-func TestCheckCompletingPenalizedPeer(t *testing.T) {
-	quit := make(chan struct{})
-	defer close(quit)
-
-	dropPeer := peerDropFn(func(id string) {})
-	enqueueCh := make(chan *enqueueRequest, 10)
-	getBlock := blockRetrievalFn(func(hash common.Hash) *types.Block { return nil })
-	getHeader := HeaderRetrievalFn(func(hash common.Hash) *types.Header { return nil })
-	chainHeight := chainHeightFn(func() uint64 { return 100 })
-
-	manager := newWitnessManager(
-		quit,
-		dropPeer,
-		enqueueCh,
-		getBlock,
-		getHeader,
-		chainHeight,
-	)
-
-	peer := "test-peer"
-	// Penalize peer first
-	manager.penalisePeer(peer)
-
-	block := createTestBlock(101)
-	fetchWitness := func(hash common.Hash, responseCh chan *eth.Response) (*eth.Request, error) {
-		return nil, nil
-	}
-
-	announce := createTestBlockAnnounce(peer, block, fetchWitness)
-
-	// Check completing with penalized peer
-	manager.checkCompleting(announce, block)
-
-	// Check that block was NOT added to pending
-	if manager.isPending(block.Hash()) {
-		t.Error("Expected block from penalized peer to be discarded")
 	}
 }
 
@@ -2037,12 +1932,6 @@ func TestSafeEnqueueSuccess(t *testing.T) {
 
 	peer := "test-peer"
 
-	// Add some peer failures first
-	manager.mu.Lock()
-	manager.failedWitnessAttempts[peer] = 5
-	manager.peerPenalty[peer] = time.Now().Add(time.Hour)
-	manager.mu.Unlock()
-
 	block := createTestBlock(101)
 	witness := createTestWitnessForBlock(block)
 	op := &blockOrHeaderInject{
@@ -2068,20 +1957,6 @@ func TestSafeEnqueueSuccess(t *testing.T) {
 
 	if reqCount != 1 {
 		t.Errorf("Expected 1 enqueue request, got %d", reqCount)
-	}
-
-	// Verify peer failures and penalty were reset
-	manager.mu.Lock()
-	failures := manager.failedWitnessAttempts[peer]
-	_, penalized := manager.peerPenalty[peer]
-	manager.mu.Unlock()
-
-	if failures != 0 {
-		t.Errorf("Expected peer failures to be reset to 0, got %d", failures)
-	}
-
-	if penalized {
-		t.Error("Expected peer penalty to be removed after successful enqueue")
 	}
 }
 
@@ -2119,7 +1994,7 @@ func TestConcurrentWitnessFetchFailure(t *testing.T) {
 	var wg sync.WaitGroup
 	numGoroutines := 100
 
-	for i := 0; i < numGoroutines; i++ {
+	for range numGoroutines {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -2128,142 +2003,4 @@ func TestConcurrentWitnessFetchFailure(t *testing.T) {
 	}
 
 	wg.Wait()
-
-	// Verify that the failure count is correct
-	manager.mu.Lock()
-	failureCount := manager.failedWitnessAttempts[peer]
-	manager.mu.Unlock()
-
-	if failureCount != numGoroutines {
-		t.Errorf("Expected failure count %d, got %d", numGoroutines, failureCount)
-	}
-}
-
-// TestHandleWitnessFetchSuccessWithBlockNoLongerPending tests handleWitnessFetchSuccess
-// when block is no longer pending
-func TestHandleWitnessFetchSuccessWithBlockNoLongerPending(t *testing.T) {
-	quit := make(chan struct{})
-	defer close(quit)
-
-	dropPeer := peerDropFn(func(id string) {})
-	enqueueCh := make(chan *enqueueRequest, 10)
-	getBlock := blockRetrievalFn(func(hash common.Hash) *types.Block { return nil })
-	getHeader := HeaderRetrievalFn(func(hash common.Hash) *types.Header { return nil })
-	chainHeight := chainHeightFn(func() uint64 { return 100 })
-
-	manager := newWitnessManager(
-		quit,
-		dropPeer,
-		enqueueCh,
-		getBlock,
-		getHeader,
-		chainHeight,
-	)
-
-	// Create test data
-	block := createTestBlock(101)
-	hash := block.Hash()
-	witness := createTestWitnessForBlock(block)
-
-	// First add the block to pending
-	manager.mu.Lock()
-	manager.pending[hash] = &witnessRequestState{
-		op: &blockOrHeaderInject{
-			origin: "test-peer",
-			block:  block,
-		},
-		announce: &blockAnnounce{
-			origin: "test-peer",
-			hash:   hash,
-			number: block.NumberU64(),
-			time:   time.Now(),
-		},
-	}
-	manager.mu.Unlock()
-
-	// Remove it to simulate the scenario
-	manager.mu.Lock()
-	delete(manager.pending, hash)
-	manager.mu.Unlock()
-
-	// Call handleWitnessFetchSuccess - should handle gracefully
-	manager.handleWitnessFetchSuccess("test-peer", hash, witness, time.Now())
-
-	// Verify no enqueue occurred
-	select {
-	case <-enqueueCh:
-		t.Error("Should not enqueue when block is no longer pending")
-	default:
-		// Expected - no enqueue
-	}
-}
-
-// TestFetchWitnessWithBlockRemovedBeforeError tests that when a block is removed from pending
-// before a fetch error occurs, the peer is not penalized
-func TestFetchWitnessWithBlockRemovedBeforeError(t *testing.T) {
-	quit := make(chan struct{})
-	defer close(quit)
-
-	dropPeer := peerDropFn(func(id string) {})
-	enqueueCh := make(chan *enqueueRequest, 10)
-	getBlock := blockRetrievalFn(func(hash common.Hash) *types.Block { return nil })
-	getHeader := HeaderRetrievalFn(func(hash common.Hash) *types.Header { return nil })
-	chainHeight := chainHeightFn(func() uint64 { return 100 })
-
-	manager := newWitnessManager(
-		quit,
-		dropPeer,
-		enqueueCh,
-		getBlock,
-		getHeader,
-		chainHeight,
-	)
-
-	// Create test data
-	block := createTestBlock(101)
-	hash := block.Hash()
-
-	// Track original failure count
-	originalFailures := 0
-
-	// Create a mock fetchWitness that removes block from pending before error
-	fetchWitness := func(h common.Hash, resCh chan *eth.Response) (*eth.Request, error) {
-		// Remove block from pending before returning error
-		manager.mu.Lock()
-		delete(manager.pending, hash)
-		originalFailures = manager.failedWitnessAttempts["test-peer"]
-		manager.mu.Unlock()
-
-		// Return an error - this should trigger the check for pending status
-		return nil, errors.New("simulated fetch error")
-	}
-
-	// Add block to pending
-	manager.mu.Lock()
-	manager.pending[hash] = &witnessRequestState{
-		op: &blockOrHeaderInject{
-			origin: "test-peer",
-			block:  block,
-		},
-		announce: &blockAnnounce{
-			origin:       "test-peer",
-			hash:         hash,
-			number:       block.NumberU64(),
-			time:         time.Now().Add(-time.Second), // Make it ready to fetch
-			fetchWitness: fetchWitness,
-		},
-	}
-	manager.mu.Unlock()
-
-	// Call fetchWitness directly to simulate the fetch attempt
-	manager.fetchWitness("test-peer", hash, manager.pending[hash].announce)
-
-	// Verify peer was not penalized (failure count should not increase)
-	manager.mu.Lock()
-	currentFailures := manager.failedWitnessAttempts["test-peer"]
-	manager.mu.Unlock()
-
-	if currentFailures > originalFailures {
-		t.Errorf("Peer should not be penalized when block is no longer pending, failures increased from %d to %d", originalFailures, currentFailures)
-	}
 }


### PR DESCRIPTION
# Description

If a peer announces a witness but responds an empty witness on a request, the peer will be deemed bad and get dropped immediately. This change will simplify the logic of witness manager and make the stateless node more resistant to bad peer behaviors. 

# Changes

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)
- [ ] Changes only for a subset of nodes

## Testing

- [x] I have added unit tests
- [ ] I have added tests to CI
- [x] I have tested this code manually on local environment
- [ ] I have tested this code manually on remote devnet using express-cli
- [ ] I have tested this code manually on amoy
- [ ] I have created new e2e tests into express-cli
