### PR TITLE
Call SetFinality when processing a milestone

### DIFF
--- a/eth/handler_bor.go
+++ b/eth/handler_bor.go
@@ -133,7 +133,6 @@ func (h *ethHandler) handleMilestone(ctx context.Context, eth *Ethereum, milesto
 	// write can't promote a stale or non-canonical header.
 	if block := eth.blockchain.GetBlockByNumber(num); block != nil && block.Hash() == hash {
 		eth.blockchain.SetFinalized(block.Header())
-		eth.blockchain.SetSafe(block.Header())
 	}
 
 	return nil

--- a/eth/handler_bor.go
+++ b/eth/handler_bor.go
@@ -128,6 +128,11 @@ func (h *ethHandler) handleMilestone(ctx context.Context, eth *Ethereum, milesto
 
 	h.downloader.ProcessMilestone(num, hash)
 
+	// set milestone block as finalized (used by tracer)
+	if header := eth.blockchain.GetHeaderByHash(hash); header != nil {
+		eth.blockchain.SetFinalized(header)
+	}
+
 	return nil
 }
 

--- a/eth/handler_bor.go
+++ b/eth/handler_bor.go
@@ -128,9 +128,12 @@ func (h *ethHandler) handleMilestone(ctx context.Context, eth *Ethereum, milesto
 
 	h.downloader.ProcessMilestone(num, hash)
 
-	// set milestone block as finalized (used by tracer)
-	if header := eth.blockchain.GetHeaderByHash(hash); header != nil {
-		eth.blockchain.SetFinalized(header)
+	// Publish the milestone block as finalized and safe. Re-resolve via the
+	// canonical number→hash mapping so a reorg between verification and this
+	// write can't promote a stale or non-canonical header.
+	if block := eth.blockchain.GetBlockByNumber(num); block != nil && block.Hash() == hash {
+		eth.blockchain.SetFinalized(block.Header())
+		eth.blockchain.SetSafe(block.Header())
 	}
 
 	return nil


### PR DESCRIPTION
# Description

`bc.CurrentFinalBlock()` is currently always `nil` on bor nodes, because the only writers of `blockchain.SetFinalized` in upstream geth are the Engine API (`eth/catalyst`), which bor does not use. As a result:

- The `headFinalizedBlockGauge` / `headSafeBlockGauge` metrics never advance.
- Any consumer that uses the standard geth `BlockChain` API to read finality — live tracers (`core.BlockchainLogger`), external indexers, downstream tooling — sees no finality on bor, even though Heimdall milestones are by definition the chain's strongest finality signal.

Bor already *knows* what's finalized: `eth/api.go:getFinalizedBlockNumber` derives it from `Downloader().GetWhitelistedMilestone()` to answer the `eth_getBlockByNumber("finalized")` RPC. This PR closes the gap by also writing that information into the canonical place (`bc.SetFinalized`) the moment a milestone has been successfully processed in `ethHandler.handleMilestone`, right after the existing `ProcessMilestone` call. The header is fetched defensively via `GetHeaderByHash`; an unknown hash is a no-op.

This PR only writes to `CurrentFinalBlock()` from milestones, because milestones are the strongest/live signal. The RPC `finalized`-tag path in `getFinalizedBlockNumber` (milestone → checkpoint fallback) is unchanged.

# Changes

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix
- [ ] New feature
- [ ] Breaking change
- [ ] Changes only for a subset of nodes

# Breaking changes

None at the protocol or RPC level. Two observable effects:

1. `headFinalizedBlockGauge` and `headSafeBlockGauge` will now advance on bor nodes (they were stuck at 0). Dashboards may need to acknowledge this.
2. The `SetHead invalidated finalized block` log path in `core/blockchain.go` becomes reachable. By construction it only triggers on a rewind below a confirmed Heimdall milestone, which is already a pathological situation — making it visible is the desired behavior.

he JSON-RPC `eth_getBlockByNumber("finalized")` response is unchanged: it still flows through `getFinalizedBlockNumber` and the downloader whitelist.

## Testing

- [ ] Unit tests
- [x] Manual on mainnet:
  - `eth_getBlockByNumber("finalized")` continues to return the latest milestoned block (unchanged).
  - `headFinalizedBlockGauge` advances after the first milestone is processed (new behavior).
  - Live tracer / `BlockChain.CurrentFinalBlock()` returns the milestone header (new behavior, previously `nil`).