### PR TITLE
chore: drop legacy // +build comment

### DIFF
--- a/tests/bor/bor_config_change_test.go
+++ b/tests/bor/bor_config_change_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 package bor
 

--- a/tests/bor/bor_test.go
+++ b/tests/bor/bor_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 package bor
 

--- a/tests/bor/fee_receiver_change_test.go
+++ b/tests/bor/fee_receiver_change_test.go
@@ -1,5 +1,4 @@
 //go:build integration
-// +build integration
 
 package bor
 


### PR DESCRIPTION
## Summary


From Go 1.17, the preferred syntax for build constraints is //go:build,
which replaces the old // +build form. The old style is now considered
deprecated but still supported for backward compatibility.

This change removes the obsolete // +build xxx line, keeping only the
modern //go:build xxx directive.

More info: https://github.com/golang/go/issues/41184 and https://go.dev/doc/go1.17#build-lines

Design Doc / Proposal：
https://go.dev/design/draft-gobuild


Inspired by https://github.com/0xPolygon/bor/pull/1931

## Executed tests
<what was actually run beyond CI's standard unit / integration / e2e gates: kurtosis scenarios, chaos runs, manual checks against Amoy / mainnet RPCs, devnet upgrades, etc. Include output or pointers to where the run lives.>

## Rollout notes
<consensus-affecting? requires coordinated upgrade? backwards-compatible? operator-facing change?>
