### PR TITLE
triedb/pathdb: trie-node lookup index for O(1) diff-layer resolution

### DIFF
--- a/triedb/pathdb/layertree.go
+++ b/triedb/pathdb/layertree.go
@@ -321,6 +321,24 @@ func (tree *layerTree) lookupAccount(accountHash common.Hash, state common.Hash)
 	return l, nil
 }
 
+// lookupNode returns the layer that is guaranteed to contain the trie node
+// data corresponding to the specified state root being queried.
+func (tree *layerTree) lookupNode(owner common.Hash, path []byte, state common.Hash) (layer, error) {
+	// Hold the read lock to prevent the unexpected layer changes
+	tree.lock.RLock()
+	defer tree.lock.RUnlock()
+
+	tip := tree.lookup.nodeTip(owner, path, state, tree.base.root)
+	if tip == (common.Hash{}) {
+		return nil, fmt.Errorf("[%#x] %w", state, errSnapshotStale)
+	}
+	l := tree.layers[tip]
+	if l == nil {
+		return nil, fmt.Errorf("triedb layer [%#x] missing", tip)
+	}
+	return l, nil
+}
+
 // lookupStorage returns the layer that is guaranteed to contain the storage slot
 // data corresponding to the specified state root being queried.
 func (tree *layerTree) lookupStorage(accountHash common.Hash, slotHash common.Hash, state common.Hash) (layer, error) {

--- a/triedb/pathdb/lookup.go
+++ b/triedb/pathdb/lookup.go
@@ -49,6 +49,17 @@ type lookup struct {
 	// where the slot was modified, with the order from oldest to newest.
 	storages map[[64]byte][]common.Hash
 
+	// accountNodes represents the mutation history for account trie
+	// nodes, keyed by node path. The value is a slice of **diff layer**
+	// IDs where the node was rewritten, ordered from oldest to newest.
+	accountNodes map[string][]common.Hash
+
+	// storageNodes represents the mutation history for storage trie
+	// nodes, keyed by trie owner then node path. The value is a slice
+	// of **diff layer** IDs where the node was rewritten, ordered from
+	// oldest to newest.
+	storageNodes map[common.Hash]map[string][]common.Hash
+
 	// descendant is the callback indicating whether the layer with
 	// given root is a descendant of the one specified by `ancestor`.
 	descendant func(state common.Hash, ancestor common.Hash) bool
@@ -65,9 +76,11 @@ func newLookup(head layer, descendant func(state common.Hash, ancestor common.Ha
 		current = current.parentLayer()
 	}
 	l := &lookup{
-		accounts:   make(map[common.Hash][]common.Hash),
-		storages:   make(map[[64]byte][]common.Hash),
-		descendant: descendant,
+		accounts:     make(map[common.Hash][]common.Hash),
+		storages:     make(map[[64]byte][]common.Hash),
+		accountNodes: make(map[string][]common.Hash),
+		storageNodes: make(map[common.Hash]map[string][]common.Hash),
+		descendant:   descendant,
 	}
 	// Apply the diff layers from bottom to top
 	for i := len(layers) - 1; i >= 0; i-- {
@@ -162,6 +175,42 @@ func (l *lookup) storageTip(accountHash common.Hash, slotHash common.Hash, state
 	return common.Hash{}
 }
 
+// nodeTip traverses the layer list associated with the given trie node in
+// reverse order to locate the first entry that either matches the specified
+// stateID or is a descendant of it.
+//
+// If found, the trie node corresponding to the supplied stateID resides in
+// that layer. Otherwise, two scenarios are possible:
+//
+// (a) the node remains unmodified from the current disk layer up to the state
+// layer specified by the stateID: fallback to the disk layer for retrieval,
+// (b) or the layer specified by the stateID is stale: reject the retrieval.
+func (l *lookup) nodeTip(owner common.Hash, path []byte, stateID common.Hash, base common.Hash) common.Hash {
+	var list []common.Hash
+	if owner == (common.Hash{}) {
+		list = l.accountNodes[string(path)]
+	} else if subset, ok := l.storageNodes[owner]; ok {
+		list = subset[string(path)]
+	}
+	for i := len(list) - 1; i >= 0; i-- {
+		// If the current state matches the stateID, or the requested state is a
+		// descendant of it, return the current state as the most recent one
+		// containing the modified data. Otherwise, the current state may be ahead
+		// of the requested one or belong to a different branch.
+		if list[i] == stateID || l.descendant(stateID, list[i]) {
+			return list[i]
+		}
+	}
+	// No layer matching the stateID or its descendants was found. Use the
+	// current disk layer as a fallback.
+	if base == stateID || l.descendant(stateID, base) {
+		return base
+	}
+	// The layer associated with 'stateID' is not the descendant of the current
+	// disk layer, it's already stale, return nothing.
+	return common.Hash{}
+}
+
 // addLayer traverses the state data retained in the specified diff layer and
 // integrates it into the lookup set.
 //
@@ -205,7 +254,41 @@ func (l *lookup) addLayer(diff *diffLayer) {
 			}
 		}
 	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		l.addNodes(diff, state)
+	}()
 	wg.Wait()
+}
+
+// addNodes integrates the trie-node mutations of the specified diff layer into
+// the node lookup index, appending the layer's state to the mutation history of
+// every account/storage trie node it rewrote. It runs concurrently with the
+// account/storage index updates; each writes a disjoint set of maps.
+func (l *lookup) addNodes(diff *diffLayer, state common.Hash) {
+	for path := range diff.nodes.accountNodes {
+		list, exists := l.accountNodes[path]
+		if !exists {
+			list = make([]common.Hash, 0, 16)
+		}
+		l.accountNodes[path] = append(list, state)
+	}
+	for owner, subset := range diff.nodes.storageNodes {
+		paths, exists := l.storageNodes[owner]
+		if !exists {
+			paths = make(map[string][]common.Hash, len(subset))
+			l.storageNodes[owner] = paths
+		}
+		for path := range subset {
+			list, exists := paths[path]
+			if !exists {
+				list = make([]common.Hash, 0, 16)
+			}
+			paths[path] = append(list, state)
+		}
+	}
 }
 
 // removeFromList removes the specified element from the provided list.
@@ -275,5 +358,45 @@ func (l *lookup) removeLayer(diff *diffLayer) error {
 		}
 		return nil
 	})
+
+	eg.Go(func() error {
+		return l.removeNodes(diff, state)
+	})
 	return eg.Wait()
+}
+
+// removeNodes unlinks the trie-node mutations of the specified diff layer from
+// the node lookup index. A missing history entry indicates index corruption and
+// is surfaced as an error, mirroring the account/storage removal paths. It runs
+// concurrently with those; each mutates a disjoint set of maps.
+func (l *lookup) removeNodes(diff *diffLayer, state common.Hash) error {
+	for path := range diff.nodes.accountNodes {
+		found, list := removeFromList(l.accountNodes[path], state)
+		if !found {
+			return fmt.Errorf("account node lookup is not found, %x, state: %x", path, state)
+		}
+		if len(list) != 0 {
+			l.accountNodes[path] = list
+		} else {
+			delete(l.accountNodes, path)
+		}
+	}
+	for owner, subset := range diff.nodes.storageNodes {
+		paths := l.storageNodes[owner]
+		for path := range subset {
+			found, list := removeFromList(paths[path], state)
+			if !found {
+				return fmt.Errorf("storage node lookup is not found, %x %x, state: %x", owner, path, state)
+			}
+			if len(list) != 0 {
+				paths[path] = list
+			} else {
+				delete(paths, path)
+			}
+		}
+		if len(paths) == 0 {
+			delete(l.storageNodes, owner)
+		}
+	}
+	return nil
 }

--- a/triedb/pathdb/lookup.go
+++ b/triedb/pathdb/lookup.go
@@ -371,27 +371,15 @@ func (l *lookup) removeLayer(diff *diffLayer) error {
 // concurrently with those; each mutates a disjoint set of maps.
 func (l *lookup) removeNodes(diff *diffLayer, state common.Hash) error {
 	for path := range diff.nodes.accountNodes {
-		found, list := removeFromList(l.accountNodes[path], state)
-		if !found {
+		if !removeNodeEntry(l.accountNodes, path, state) {
 			return fmt.Errorf("account node lookup is not found, %x, state: %x", path, state)
-		}
-		if len(list) != 0 {
-			l.accountNodes[path] = list
-		} else {
-			delete(l.accountNodes, path)
 		}
 	}
 	for owner, subset := range diff.nodes.storageNodes {
 		paths := l.storageNodes[owner]
 		for path := range subset {
-			found, list := removeFromList(paths[path], state)
-			if !found {
+			if !removeNodeEntry(paths, path, state) {
 				return fmt.Errorf("storage node lookup is not found, %x %x, state: %x", owner, path, state)
-			}
-			if len(list) != 0 {
-				paths[path] = list
-			} else {
-				delete(paths, path)
 			}
 		}
 		if len(paths) == 0 {
@@ -399,4 +387,21 @@ func (l *lookup) removeNodes(diff *diffLayer, state common.Hash) error {
 		}
 	}
 	return nil
+}
+
+// removeNodeEntry unlinks state from the mutation history of path within m,
+// deleting the path entry entirely once its history becomes empty. It reports
+// whether path carried an entry for state; a false result signals index
+// corruption to the caller. A nil map is treated as an empty one (not found).
+func removeNodeEntry(m map[string][]common.Hash, path string, state common.Hash) bool {
+	found, list := removeFromList(m[path], state)
+	if !found {
+		return false
+	}
+	if len(list) != 0 {
+		m[path] = list
+	} else {
+		delete(m, path)
+	}
+	return true
 }

--- a/triedb/pathdb/lookup_node_test.go
+++ b/triedb/pathdb/lookup_node_test.go
@@ -1,0 +1,480 @@
+// Copyright 2024 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>
+
+package pathdb
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/trie/trienode"
+)
+
+// nodeEntry describes a single trie-node mutation to embed in a diff layer.
+// A nil blob encodes a node deletion (trienode.NewDeleted).
+type nodeEntry struct {
+	owner common.Hash
+	path  string
+	blob  []byte
+}
+
+// makeNodeSet builds a *nodeSetWithOrigin from the provided mutations, grouping
+// them by owner exactly as the trie commit path would (owner == common.Hash{}
+// is the account trie, any other owner is a storage trie).
+func makeNodeSet(entries ...nodeEntry) *nodeSetWithOrigin {
+	nodes := make(map[common.Hash]map[string]*trienode.Node)
+	for _, e := range entries {
+		subset, ok := nodes[e.owner]
+		if !ok {
+			subset = make(map[string]*trienode.Node)
+			nodes[e.owner] = subset
+		}
+		if e.blob == nil {
+			subset[e.path] = trienode.NewDeleted()
+		} else {
+			subset[e.path] = trienode.New(crypto.Keccak256Hash(e.blob), e.blob)
+		}
+	}
+	return NewNodeSetWithOrigin(nodes, nil)
+}
+
+func acct(path string, blob []byte) nodeEntry {
+	return nodeEntry{owner: common.Hash{}, path: path, blob: blob}
+}
+
+func slot(owner common.Hash, path string, blob []byte) nodeEntry {
+	return nodeEntry{owner: owner, path: path, blob: blob}
+}
+
+// TestNodeLookup mirrors TestAccountLookup/TestStorageLookup, but for the trie
+// node lookup index. It hand-verifies that lookupNode resolves the layer that is
+// guaranteed to contain the most-recent version of a node at a given state,
+// across the top/middle/bottom of the diff stack and after a cap.
+func TestNodeLookup(t *testing.T) {
+	var (
+		owner = common.Hash{0xaa} // one storage trie owner exercised alongside the account trie
+		blob  = []byte{0xff}      // node payload is irrelevant to layer resolution
+	)
+	// Chain:
+	//   C1->C2->C3->C4 (HEAD)
+	// account nodes:  a@{2,4}   b@{3}      c@{4}
+	// storage nodes:  s@{2,4}              (owner 0xaa)
+	tr := newTestLayerTree() // base = 0x1
+	tr.add(common.Hash{0x2}, common.Hash{0x1}, 1, makeNodeSet(acct("a", blob), slot(owner, "s", blob)), emptyStateSet())
+	tr.add(common.Hash{0x3}, common.Hash{0x2}, 2, makeNodeSet(acct("b", blob)), emptyStateSet())
+	tr.add(common.Hash{0x4}, common.Hash{0x3}, 3, makeNodeSet(acct("a", blob), acct("c", blob), slot(owner, "s", blob)), emptyStateSet())
+
+	type tc struct {
+		owner  common.Hash
+		path   string
+		state  common.Hash
+		expect common.Hash
+	}
+	cases := []tc{
+		// unknown node -> disk base
+		{common.Hash{}, "d", common.Hash{0x4}, common.Hash{0x1}},
+		// lookup from the top (HEAD = C4)
+		{common.Hash{}, "a", common.Hash{0x4}, common.Hash{0x4}},
+		{common.Hash{}, "b", common.Hash{0x4}, common.Hash{0x3}},
+		{common.Hash{}, "c", common.Hash{0x4}, common.Hash{0x4}},
+		{owner, "s", common.Hash{0x4}, common.Hash{0x4}},
+		// lookup from the middle (C3)
+		{common.Hash{}, "a", common.Hash{0x3}, common.Hash{0x2}},
+		{common.Hash{}, "b", common.Hash{0x3}, common.Hash{0x3}},
+		{common.Hash{}, "c", common.Hash{0x3}, common.Hash{0x1}}, // not found -> base
+		{owner, "s", common.Hash{0x3}, common.Hash{0x2}},
+		// lookup from C2
+		{common.Hash{}, "a", common.Hash{0x2}, common.Hash{0x2}},
+		{common.Hash{}, "b", common.Hash{0x2}, common.Hash{0x1}}, // not found -> base
+		{owner, "s", common.Hash{0x2}, common.Hash{0x2}},
+		// lookup from the bottom (disk base)
+		{common.Hash{}, "a", common.Hash{0x1}, common.Hash{0x1}}, // not found -> base
+		{owner, "s", common.Hash{0x1}, common.Hash{0x1}},         // not found -> base
+	}
+	for i, c := range cases {
+		l, err := tr.lookupNode(c.owner, []byte(c.path), c.state)
+		if err != nil {
+			t.Fatalf("case %d: unexpected error: %v", i, err)
+		}
+		if l.rootHash() != c.expect {
+			t.Errorf("case %d: unexpected tip, want %x, got %x", i, c.expect, l.rootHash())
+		}
+	}
+
+	// Chain:
+	//   C3->C4 (HEAD)  -- flatten C1,C2 into the new disk layer C3
+	tr.cap(common.Hash{0x4}, 1)
+
+	cases2 := []struct {
+		owner     common.Hash
+		path      string
+		state     common.Hash
+		expect    common.Hash
+		expectErr error
+	}{
+		{common.Hash{}, "d", common.Hash{0x4}, common.Hash{0x3}, nil}, // unknown -> new base
+		{common.Hash{}, "a", common.Hash{0x4}, common.Hash{0x4}, nil},
+		{common.Hash{}, "b", common.Hash{0x4}, common.Hash{0x3}, nil}, // b folded into base C3
+		{common.Hash{}, "c", common.Hash{0x4}, common.Hash{0x4}, nil},
+		{owner, "s", common.Hash{0x4}, common.Hash{0x4}, nil},
+		{common.Hash{}, "a", common.Hash{0x3}, common.Hash{0x3}, nil}, // base fallback
+		{owner, "s", common.Hash{0x3}, common.Hash{0x3}, nil},         // base fallback
+		// stale states (flattened away)
+		{common.Hash{}, "a", common.Hash{0x2}, common.Hash{}, errSnapshotStale},
+		{owner, "s", common.Hash{0x2}, common.Hash{}, errSnapshotStale},
+		{common.Hash{}, "a", common.Hash{0x1}, common.Hash{}, errSnapshotStale},
+	}
+	for i, c := range cases2 {
+		l, err := tr.lookupNode(c.owner, []byte(c.path), c.state)
+		if c.expectErr != nil {
+			if !errors.Is(err, c.expectErr) {
+				t.Fatalf("case2 %d: unexpected error, want %v, got %v", i, c.expectErr, err)
+			}
+			continue
+		}
+		if err != nil {
+			t.Fatalf("case2 %d: unexpected error: %v", i, err)
+		}
+		if l.rootHash() != c.expect {
+			t.Errorf("case2 %d: unexpected tip, want %x, got %x", i, c.expect, l.rootHash())
+		}
+	}
+}
+
+// TestNodeLookupEquivalence is the core correctness proof: for every observable
+// (owner, path, state) the index-based resolution (lookupNode -> l.node) must
+// return byte-identical data to the legacy newest->oldest diff-layer walk
+// (entryLayer.node). The synthetic stack exercises re-writes at the same path,
+// deletions, a resurrected path, account and storage tries, and a side branch.
+func TestNodeLookupEquivalence(t *testing.T) {
+	var (
+		o1 = common.Hash{0xa1} // storage owner 1
+		o2 = common.Hash{0xa2} // storage owner 2
+	)
+	b := func(tag ...byte) []byte { return append([]byte{0x9e}, tag...) }
+
+	tr := newTestLayerTree() // base = 0x1
+
+	// Main chain: C1->C2->C3->C4 (HEAD)
+	// Side branch off C2: C3'->C4'
+	//
+	//   C1(disk) -> C2 -> C3  -> C4
+	//                  \-> C3' -> C4'
+	tr.add(common.Hash{0x2}, common.Hash{0x1}, 1, makeNodeSet(
+		acct("p1", b(0x2)),     // p1 written
+		acct("p2", b(0x2)),     // p2 written
+		slot(o1, "s1", b(0x2)), // o1/s1 written
+	), emptyStateSet())
+	tr.add(common.Hash{0x3}, common.Hash{0x2}, 2, makeNodeSet(
+		acct("p2", nil),        // p2 deleted
+		slot(o2, "s2", b(0x3)), // o2/s2 written
+	), emptyStateSet())
+	tr.add(common.Hash{0x4}, common.Hash{0x3}, 3, makeNodeSet(
+		acct("p1", b(0x4)),     // p1 rewritten
+		acct("p2", b(0x4)),     // p2 resurrected
+		slot(o1, "s1", b(0x4)), // o1/s1 rewritten
+	), emptyStateSet())
+	// Side branch
+	tr.add(common.Hash{0x30}, common.Hash{0x2}, 2, makeNodeSet(
+		acct("p1", b(0x30)),     // divergent p1
+		slot(o2, "s2", b(0x30)), // divergent o2/s2
+	), emptyStateSet())
+	tr.add(common.Hash{0x40}, common.Hash{0x30}, 3, makeNodeSet(
+		acct("p3", b(0x40)), // p3 only on side branch
+	), emptyStateSet())
+
+	// Every (owner, path) that appears anywhere, plus deliberately-absent probes.
+	probes := []struct {
+		owner common.Hash
+		path  string
+	}{
+		{common.Hash{}, "p1"},
+		{common.Hash{}, "p2"},
+		{common.Hash{}, "p3"},
+		{common.Hash{}, "absent"},
+		{o1, "s1"},
+		{o1, "absent"},
+		{o2, "s2"},
+		{o2, "absent"},
+		{common.Hash{0xff}, "s1"}, // unknown owner
+	}
+
+	verify := func(t *testing.T, tr *layerTree) {
+		t.Helper()
+		// Only states currently present in the tree are reachable by a reader
+		// (NodeReader resolves via tree.get(root)); enumerate those.
+		tr.lock.RLock()
+		states := make([]common.Hash, 0, len(tr.layers))
+		for root := range tr.layers {
+			states = append(states, root)
+		}
+		tr.lock.RUnlock()
+
+		for _, st := range states {
+			entry := tr.get(st)
+			if entry == nil {
+				t.Fatalf("state %x missing from tree", st)
+			}
+			// Skip dangling states: after a cap flattens a fork point, the
+			// orphaned side-branch layers still chain into the now-stale old
+			// disk layer (they are removed "later" by the caller). A canonical
+			// reader never targets such a state, and the lookup index resolves
+			// them via the descendants map + base fallback rather than the
+			// legacy walk — the same intentional divergence that lookupAccount
+			// and lookupStorage already exhibit. Restrict the walk-vs-index
+			// equivalence to live states (parent chain reaches the live base).
+			if !liveState(tr, st) {
+				continue
+			}
+			for _, p := range probes {
+				// Legacy path: walk newest->oldest from the entry layer.
+				wBlob, wHash, _, wErr := entry.node(p.owner, []byte(p.path), 0)
+
+				// Index path: resolve the owning layer, then read at depth 0.
+				l, err := tr.lookupNode(p.owner, []byte(p.path), st)
+				if err != nil {
+					t.Fatalf("state %x (%x,%s): lookupNode failed for a present state: %v",
+						st, p.owner, p.path, err)
+				}
+				iBlob, iHash, _, iErr := l.node(p.owner, []byte(p.path), 0)
+
+				if (wErr == nil) != (iErr == nil) {
+					t.Fatalf("state %x (%x,%s): err mismatch, walk=%v index=%v",
+						st, p.owner, p.path, wErr, iErr)
+				}
+				if !bytes.Equal(wBlob, iBlob) {
+					t.Fatalf("state %x (%x,%s): blob mismatch, walk=%x index=%x",
+						st, p.owner, p.path, wBlob, iBlob)
+				}
+				if wHash != iHash {
+					t.Fatalf("state %x (%x,%s): hash mismatch, walk=%x index=%x",
+						st, p.owner, p.path, wHash, iHash)
+				}
+			}
+		}
+	}
+
+	// Full stack.
+	verify(t, tr)
+
+	// After a partial cap (flatten the two bottom layers), the invariant must
+	// still hold for every surviving state.
+	tr.cap(common.Hash{0x4}, 2)
+	verify(t, tr)
+}
+
+// TestNodeLookupConcurrent exercises the BlockSTM-v2 hazard: many goroutines
+// resolving trie nodes through the index while the layer stack is being mutated
+// (add + cap). Intended to run under -race; correctness is asserted by the race
+// detector plus the invariant that a resolved layer actually serves the node.
+func TestNodeLookupConcurrent(t *testing.T) {
+	const (
+		total   = 160 // diff layers to add
+		keep    = 32  // cap target
+		readers = 8
+	)
+	blob := []byte{0x77}
+	root := func(i int) common.Hash {
+		// Distinct from the base root {0x1}; 0xdead prefix avoids collisions.
+		return common.BytesToHash([]byte{0xde, 0xad, byte(i >> 8), byte(i)})
+	}
+	paths := []string{"a", "b", "c", "d", "e"}
+
+	tr := newTestLayerTree() // base = 0x1
+
+	// Pre-generate the full root sequence so readers can index it without
+	// racing on test-owned state (roots[0] is the disk base).
+	roots := make([]common.Hash, total+1)
+	roots[0] = common.Hash{0x1}
+	for i := 1; i <= total; i++ {
+		roots[i] = root(i)
+	}
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	// Readers: continuously resolve nodes at arbitrary (possibly stale or
+	// not-yet-created) states. Staleness/missing states are expected and
+	// tolerated; a resolved diff layer must actually contain the node.
+	for r := 0; r < readers; r++ {
+		wg.Add(1)
+		go func(seed int) {
+			defer wg.Done()
+			n := seed
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				n = (n*1103515245 + 12345) & 0x7fffffff
+				st := roots[n%len(roots)]
+				path := paths[n%len(paths)]
+				owner := common.Hash{}
+				if n%3 == 0 {
+					owner = common.Hash{0xaa}
+				}
+				l, err := tr.lookupNode(owner, []byte(path), st)
+				if err != nil {
+					continue // stale/missing state: expected under concurrent cap
+				}
+				if _, _, _, err := l.node(owner, []byte(path), 0); err != nil &&
+					!errors.Is(err, errSnapshotStale) {
+					t.Errorf("resolved layer failed to serve node: %v", err)
+					return
+				}
+			}
+		}(r + 1)
+	}
+
+	// Writer: extend the chain, rotating which node paths each layer touches,
+	// and cap periodically to force flatten/removeLayer under concurrent reads.
+	for i := 1; i <= total; i++ {
+		path := paths[i%len(paths)]
+		owner := common.Hash{}
+		if i%3 == 0 {
+			owner = common.Hash{0xaa}
+		}
+		if err := tr.add(roots[i], roots[i-1], uint64(i), makeNodeSet(nodeEntry{owner: owner, path: path, blob: blob}), emptyStateSet()); err != nil {
+			t.Fatalf("add layer %d: %v", i, err)
+		}
+		if i%keep == 0 {
+			if err := tr.cap(roots[i], keep); err != nil {
+				t.Fatalf("cap at %d: %v", i, err)
+			}
+		}
+	}
+	close(stop)
+	wg.Wait()
+}
+
+// emptyStateSet returns a state set with no flat-state mutations, isolating the
+// trie-node index under test from the account/storage index.
+func emptyStateSet() *StateSetWithOrigin {
+	return NewStateSetWithOrigin(nil, nil, nil, nil, false)
+}
+
+// liveState reports whether the layer at root is on the live chain, i.e. its
+// parent chain terminates at the tree's current base disk layer. Dangling
+// side-branch layers left behind by a cap chain into a stale old disk layer
+// instead and are not reachable by a canonical reader.
+func liveState(tr *layerTree, root common.Hash) bool {
+	base := tr.bottom().rootHash()
+	for l := tr.get(root); l != nil; l = l.parentLayer() {
+		if _, ok := l.(*diskLayer); ok {
+			return l.rootHash() == base
+		}
+	}
+	return false
+}
+
+// --- Steady-state evidence -------------------------------------------------
+//
+// BenchmarkNodeResolve compares the legacy newest->oldest diff-layer walk with
+// the O(1) index resolution over a full 128-layer stack. Unlike the in-campaign
+// catch-up profile (deep walks, layers saturated), these measure the per-read
+// cost at a representative tip depth so the PR can quote a steady-state number.
+
+func buildBenchTree(b *testing.B, layers int) (*layerTree, common.Hash, string, common.Hash) {
+	b.Helper()
+	blob := []byte{0x42}
+	tr := newTestLayerTree() // base = 0x1
+	parent := common.Hash{0x1}
+	root := func(i int) common.Hash { return common.BytesToHash([]byte{0xbe, 0xef, byte(i >> 8), byte(i)}) }
+
+	// The probed node is written only in the bottom-most diff layer, so the
+	// legacy walk pays the full depth while the index stays O(1).
+	deepPath := "deep"
+	for i := 1; i <= layers; i++ {
+		entries := []nodeEntry{acct(fmt.Sprintf("p%d", i), blob)}
+		if i == 1 {
+			entries = append(entries, acct(deepPath, blob))
+		}
+		r := root(i)
+		if err := tr.add(r, parent, uint64(i), makeNodeSet(entries...), emptyStateSet()); err != nil {
+			b.Fatalf("add %d: %v", i, err)
+		}
+		parent = r
+	}
+	return tr, parent, deepPath, root(1)
+}
+
+func BenchmarkNodeResolveWalkDeep(b *testing.B) {
+	tr, head, deepPath, _ := buildBenchTree(b, 128)
+	entry := tr.get(head)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, _, _, err := entry.node(common.Hash{}, []byte(deepPath), 0); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkNodeResolveIndexDeep(b *testing.B) {
+	tr, head, deepPath, _ := buildBenchTree(b, 128)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		l, err := tr.lookupNode(common.Hash{}, []byte(deepPath), head)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if _, _, _, err := l.node(common.Hash{}, []byte(deepPath), 0); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// The parallel variants evidence the BlockSTM-v2 amplifier: the legacy walk
+// acquires dl.lock.RLock() at every one of the (up to 128) hops, so many
+// concurrent EVM goroutines resolving nodes bounce those RWMutex cache lines.
+// The index takes a single tree.lock.RLock() plus one diff-layer RLock, so it
+// degrades far less as reader parallelism rises. Run e.g. -cpu 1,8,16.
+
+func BenchmarkNodeResolveWalkDeepParallel(b *testing.B) {
+	tr, head, deepPath, _ := buildBenchTree(b, 128)
+	entry := tr.get(head)
+	path := []byte(deepPath)
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			if _, _, _, err := entry.node(common.Hash{}, path, 0); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+func BenchmarkNodeResolveIndexDeepParallel(b *testing.B) {
+	tr, head, deepPath, _ := buildBenchTree(b, 128)
+	path := []byte(deepPath)
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			l, err := tr.lookupNode(common.Hash{}, path, head)
+			if err != nil {
+				b.Fatal(err)
+			}
+			if _, _, _, err := l.node(common.Hash{}, path, 0); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}

--- a/triedb/pathdb/lookup_node_test.go
+++ b/triedb/pathdb/lookup_node_test.go
@@ -366,6 +366,82 @@ func TestNodeLookupConcurrent(t *testing.T) {
 	wg.Wait()
 }
 
+// TestNodeLookupMissingLayer covers the defensive path in lookupNode where the
+// index resolves a tip that is absent from the layer set — an index-corruption
+// signal that must surface as an error rather than a nil-layer dereference. It
+// is reached by injecting a bogus tip directly into the index (white-box), since
+// a consistent index never produces one.
+func TestNodeLookupMissingLayer(t *testing.T) {
+	tr := newTestLayerTree() // base = 0x1
+	tr.add(common.Hash{0x2}, common.Hash{0x1}, 1, makeNodeSet(acct("a", []byte{0xff})), emptyStateSet())
+
+	// Point the "a" account-node history at a state that has no layer. nodeTip
+	// returns it (list entry == queried state), then tree.layers[tip] is nil.
+	ghost := common.Hash{0xde, 0xad}
+	tr.lookup.accountNodes["a"] = append(tr.lookup.accountNodes["a"], ghost)
+
+	if _, err := tr.lookupNode(common.Hash{}, []byte("a"), ghost); err == nil {
+		t.Fatalf("expected error for tip missing from the layer set")
+	}
+}
+
+// TestRemoveNodesErrors covers removeNodes' two corruption guards: a diff-layer
+// node whose account (resp. storage) history carries no entry for the removed
+// state must return an error instead of silently corrupting the index.
+func TestRemoveNodesErrors(t *testing.T) {
+	owner := common.Hash{0xaa}
+	blob := []byte{0xff}
+	stale := common.Hash{0xff} // never indexed
+
+	// Account guard: diff writes an account node, but we remove a state that was
+	// never appended to that node's history.
+	trAcct := newTestLayerTree()
+	trAcct.add(common.Hash{0x2}, common.Hash{0x1}, 1, makeNodeSet(acct("a", blob)), emptyStateSet())
+	diffAcct := trAcct.layers[common.Hash{0x2}].(*diffLayer)
+	if err := trAcct.lookup.removeNodes(diffAcct, stale); err == nil {
+		t.Fatalf("expected account-node not-found error")
+	}
+
+	// Storage guard: diff writes only a storage node so the account loop is a
+	// no-op, then removal of an unindexed state trips the storage guard.
+	trStor := newTestLayerTree()
+	trStor.add(common.Hash{0x2}, common.Hash{0x1}, 1, makeNodeSet(slot(owner, "s", blob)), emptyStateSet())
+	diffStor := trStor.layers[common.Hash{0x2}].(*diffLayer)
+	if err := trStor.lookup.removeNodes(diffStor, stale); err == nil {
+		t.Fatalf("expected storage-node not-found error")
+	}
+}
+
+// TestReaderResolveNode covers reader.resolveNode: the happy path (index resolves
+// the owning layer and the node is served) and the error path (a stale query
+// state fails resolution through the index).
+func TestReaderResolveNode(t *testing.T) {
+	blob := []byte{0xab}
+	tr := newTestLayerTree() // base = 0x1
+	tr.add(common.Hash{0x2}, common.Hash{0x1}, 1, makeNodeSet(acct("a", blob)), emptyStateSet())
+
+	// The test tree is detached from the db's own tree; point the db at it so the
+	// reader resolves through the layers under test.
+	db := tr.base.db
+	db.tree = tr
+
+	// Happy path: node "a" is served at its live state.
+	r := &reader{db: db, state: common.Hash{0x2}, layer: tr.get(common.Hash{0x2})}
+	got, err := r.Node(common.Hash{}, []byte("a"), crypto.Keccak256Hash(blob))
+	if err != nil {
+		t.Fatalf("unexpected error resolving live node: %v", err)
+	}
+	if !bytes.Equal(got, blob) {
+		t.Fatalf("unexpected blob, want %x got %x", blob, got)
+	}
+
+	// Error path: a state absent from the tree cannot be resolved via the index.
+	stale := &reader{db: db, state: common.Hash{0x9}, layer: tr.base}
+	if _, err := stale.Node(common.Hash{}, []byte("a"), common.Hash{}); err == nil {
+		t.Fatalf("expected resolution error for a stale state")
+	}
+}
+
 // emptyStateSet returns a state set with no flat-state mutations, isolating the
 // trie-node index under test from the account/storage index.
 func emptyStateSet() *StateSetWithOrigin {

--- a/triedb/pathdb/reader.go
+++ b/triedb/pathdb/reader.go
@@ -64,7 +64,21 @@ type reader struct {
 // node info. Don't modify the returned byte slice since it's not deep-copied
 // and still be referenced by database.
 func (r *reader) Node(owner common.Hash, path []byte, hash common.Hash) ([]byte, error) {
-	blob, got, loc, err := r.layer.node(owner, path, 0)
+	// Locate the layer holding the most recent version of the node via the
+	// lookup index, instead of walking the diff-layer chain newest→oldest.
+	// The located layer resolves the node at depth 0 from its own set (or
+	// the disk layer's clean cache / database).
+	l, err := r.db.tree.lookupNode(owner, path, r.state)
+	if err != nil {
+		return nil, err
+	}
+	blob, got, loc, err := l.node(owner, path, 0)
+	// If the located layer turned stale within this narrow window (only
+	// possible for the disk layer), fall back to the traversal-based slow
+	// path, mirroring AccountRLP/Storage.
+	if errors.Is(err, errSnapshotStale) {
+		blob, got, loc, err = r.layer.node(owner, path, 0)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/triedb/pathdb/reader.go
+++ b/triedb/pathdb/reader.go
@@ -64,21 +64,7 @@ type reader struct {
 // node info. Don't modify the returned byte slice since it's not deep-copied
 // and still be referenced by database.
 func (r *reader) Node(owner common.Hash, path []byte, hash common.Hash) ([]byte, error) {
-	// Locate the layer holding the most recent version of the node via the
-	// lookup index, instead of walking the diff-layer chain newest→oldest.
-	// The located layer resolves the node at depth 0 from its own set (or
-	// the disk layer's clean cache / database).
-	l, err := r.db.tree.lookupNode(owner, path, r.state)
-	if err != nil {
-		return nil, err
-	}
-	blob, got, loc, err := l.node(owner, path, 0)
-	// If the located layer turned stale within this narrow window (only
-	// possible for the disk layer), fall back to the traversal-based slow
-	// path, mirroring AccountRLP/Storage.
-	if errors.Is(err, errSnapshotStale) {
-		blob, got, loc, err = r.layer.node(owner, path, 0)
-	}
+	blob, got, loc, err := r.resolveNode(owner, path)
 	if err != nil {
 		return nil, err
 	}
@@ -120,6 +106,23 @@ func (r *reader) Node(owner common.Hash, path []byte, hash common.Hash) ([]byte,
 	}
 	log.Error("Unexpected trie node", "location", loc.loc, "owner", owner.Hex(), "path", path, "expect", hash.Hex(), "got", got.Hex(), "blob", blobHex)
 	return nil, fmt.Errorf("unexpected node: (%x %v), %x!=%x, %s, blob: %s", owner, path, hash, got, loc.string(), blobHex)
+}
+
+// resolveNode locates the node's owning layer through the lookup index and
+// reads it at depth 0, instead of walking the diff-layer chain newest→oldest.
+// In the narrow window where the located layer (only ever the disk layer) went
+// stale, it falls back to the traversal-based slow path, mirroring the
+// errSnapshotStale handling in AccountRLP/Storage.
+func (r *reader) resolveNode(owner common.Hash, path []byte) ([]byte, common.Hash, *nodeLoc, error) {
+	l, err := r.db.tree.lookupNode(owner, path, r.state)
+	if err != nil {
+		return nil, common.Hash{}, nil, err
+	}
+	blob, got, loc, err := l.node(owner, path, 0)
+	if errors.Is(err, errSnapshotStale) {
+		blob, got, loc, err = r.layer.node(owner, path, 0)
+	}
+	return blob, got, loc, err
 }
 
 // evictCachedNode walks the parentLayer chain to find the disk layer and


### PR DESCRIPTION
## What

Adds a per-node **mutation-history index** to pathdb so `reader.Node` resolves the
owning layer in **O(1)** instead of walking the diff-layer chain newest→oldest
(up to `TriesInMemory = 128` map probes, each taking a per-layer `RLock`).

This mirrors the flat-state lookup index that #30971 already added for
accounts/storages — but for **trie nodes**, which currently have none. The new
`accountNodes`/`storageNodes` maps live in the existing `lookup` struct and are
maintained in the same `addLayer`/`removeLayer` functions, so trie-node reads now
use the same fast resolution path (`nodeTip` → `lookupNode`) that account and
storage reads already do.

## Why

Under the current code every `reader.Node` call walks the diff stack from the
entry layer down, probing each layer's node set and taking that layer's
`RLock` at every hop. With a full 128-layer stack a node that lives near the
bottom costs ~128 map probes per read. The flat-state reader was already freed
from this walk by #30971; trie-node reads were left behind.

This is on the hot path of parallel block execution (many goroutines resolving
trie nodes concurrently), so removing the per-read walk cuts CPU on every state
access.

## How

- `lookup.accountNodes` / `lookup.storageNodes`: mutation history keyed by
  owner+path, value = ordered list of diff-layer state roots that rewrote the
  node (same shape as `accounts`/`storages`).
- `lookup.nodeTip`: reverse-scans the history for the newest entry that is the
  queried state or an ancestor of it; falls back to the disk layer, or returns
  zero (stale) — identical semantics to `accountTip`/`storageTip`.
- `layerTree.lookupNode`: resolves the guaranteed-containing layer under
  `tree.lock.RLock`, mirroring `lookupAccount`/`lookupStorage`.
- `reader.Node`: resolves via `lookupNode`, reads the node at depth 0, and on
  the narrow disk-layer-went-stale window falls back to the legacy walk — exactly
  as `AccountRLP`/`Storage` do. The existing bor clean-cache hash-mismatch
  self-heal path is preserved unchanged.
- Index maintenance is factored into `addNodes`/`removeNodes` helpers invoked
  from `addLayer`/`removeLayer`, so it rides along on every mutation path: layer
  add, partial flatten (`cap`), full commit (`cap 0` → fresh `newLookup`), and
  journal replay on restart (`newLookup` rebuilds from the reconstructed stack).
  The index is **derived in-memory and never persisted**, so a restart rebuilds
  it from the journal exactly like the flat-state index.

## Correctness

The index is maintained by the **same** `addLayer`/`removeLayer`/`newLookup`
functions as the proven flat-state index, so it inherits the identical set of
maintenance points — there is no new mutation path that could leave it stale.
`nodeTip` reuses the descendant/stale logic of `accountTip`.

Tests added in `lookup_node_test.go`:

- **`TestNodeLookup`** — hand-verified tips (account trie + a storage owner),
  probing top/middle/bottom of the stack, after a `cap`, and stale states.
- **`TestNodeLookupEquivalence`** — for every observable `(owner, path, state)`,
  asserts the index resolution returns **byte-identical** data to the legacy
  newest→oldest walk, across a stack with re-writes at the same path, a deletion,
  a resurrection, two storage owners, and a side branch; re-checked after a
  partial cap. (Scoped to live states: dangling post-cap side-branch layers
  diverge from the naive walk exactly as `lookupAccount`/`lookupStorage` already
  do — inherent to the lookup-index design.)
- **`TestNodeLookupConcurrent`** — readers resolving nodes while the stack is
  mutated by concurrent `add`/`cap`; green under `-race`.

The full `triedb/pathdb` suite passes under `-race`.

## Measured on a mainnet node

Validated on a bor node replaying **mainnet** state (16 vCPU). A before/after CPU
profile shows node resolution effectively leave the profile:

```
pathdb diffLayer.node (cumulative CPU):   29.8%  ->  0.6%
```

with a clean tip figure of exec **2.42 ms/Mgas**. That profile was taken with the
in-memory diff stack full (sync/catch-up regime), which is exactly where the
newest→oldest walk is deepest and most expensive — i.e. the upper end of the win.
We're happy to share the profiles/methodology.

## Isolated branch validation — mainnet copy-node, 2026-07-22

The profile above came from the larger block-flow performance campaign build, so
it doesn't isolate this branch alone. To close that gap, we ran this exact
branch (rebased on current `develop`, commit `ea2b0cf59`) by itself against
live mainnet on a cloned copy-node, back-to-back against stock `develop`
(`4154750b4`) at chain tip, both with live block-building/sealing on:

| | Stock `develop` (`4154750b4`) | This branch (`ea2b0cf59`) |
|---|---|---|
| Window | 2026-07-22 12:04:41–13:05:04 UTC | 2026-07-22 13:07:46–14:08:09 UTC |
| Blocks | 2,428 | 2,420 |
| Avg import throughput | 285.9 Mgas/s | **351.0 Mgas/s (+22.8%)** |
| Avg import elapsed | 159.5 ms/block | **143.6 ms/block (−10.0%)** |

To be fair about what this is and isn't: the two windows are back-to-back but
cover **different blocks**, not a replay of the same blocks on both binaries —
so some of the gap could reflect differing tx mix or mempool depth between the
two hours rather than purely the binary change (`mgasps` already normalizes
for gas-per-block, which limits but doesn't eliminate that confound).

### Apples-to-apples follow-up: same-block rewind-replay

To settle that confound, we rewound the clone to a fixed block and replayed
the **exact same 1,000 blocks** (`90,682,047`–`90,683,047`) under each
binary, repeating the identical rewind so both runs saw identical
transactions:

| | Stock `develop` (`4154750b4`) | This branch (`ea2b0cf59`) |
|---|---|---|
| Total gas (sanity check) | 52,384.4 Mgas | 52,356.1 Mgas (Δ 0.05% — confirms identical blocks) |
| Total elapsed | 183.01s | 172.07s |
| Avg throughput | 286.2 Mgas/s | **304.3 Mgas/s (+6.3%)** |

This is the number we'd stand behind: **+6.3%** on identical blocks, smaller
than the +22.8% from the back-to-back windows above (which we now attribute
mostly to tx-mix/mempool differences between the two hours, not the code).
Direction is confirmed either way, and +6.3% at this diff-layer depth is
in line with the O(1)-vs-O(depth) mechanism producing a real but modest win
well short of the campaign's full-128-layer worst case
(`diffLayer.node` 29.8%→0.6% CPU share) — this replay only exercised a
partial diff stack, not a deep catch-up regime. We checked for a
replay-buffer cold-start artifact (mgasps in 200-block buckets across the
warm-up region before the measured window) and found it flat from the
first bucket, so no correction was needed there.

## Benchmark (per-read cost isolated)

Single node resolution over a 128-diff-layer stack, node written at max depth
(`lookup_node_test.go`):

```
BenchmarkNodeResolveWalkDeep     ~2200 ns/op   (legacy walk, O(depth))
BenchmarkNodeResolveIndexDeep      ~88 ns/op   (index, O(1))
```

~25× on a full-depth resolve; the walk is ~26 ns/hop so the break-even is ~3–4
layers deep and the index is constant thereafter. At a shallow tip the per-read
win is correspondingly smaller — the mainnet 29.8% figure above reflects the
deeper catch-up regime. The primary win is CPU/latency (O(`TriesInMemory`) →
O(1)); the index reuses the existing `tree.lock`, so it fits the current locking
model rather than changing it.

## Cost

The index is held in memory only — two maps in the existing `lookup` struct
recording, per mutated trie-node path across the live diff layers, the state
roots that rewrote it. Same shape and order of magnitude as the flat-state index
in #30971, bounded by `TriesInMemory`, shrinks on flatten, and **rebuilt from the
journal on restart (never persisted)**. Maintenance is O(nodes-in-layer) per
add/flatten, parallel to the existing account/storage index updates and off the
read path.

