### PR TITLE
consensus/bor: don't leak the live tracer into non-import system transactions

### DIFF
--- a/consensus/bor/bor.go
+++ b/consensus/bor/bor.go
@@ -1778,6 +1778,34 @@ func (c *Bor) runMilestoneFetcher() {
 	}
 }
 
+// stateTracingHooks is implemented by state wrappers (state.NewHookedState)
+// that emit tracing hooks for the state they wrap.
+type stateTracingHooks interface {
+	Hooks() *tracing.Hooks
+}
+
+// systemTxVMConfig returns the vm.Config to use when applying bor system
+// transactions (span commits and state-sync events) over the given state.
+//
+// The tracer is derived from the state itself rather than taken from
+// c.vmConfig: canonical block import passes a hooked state when a live tracer
+// is configured, so system transactions keep being traced there. Every other
+// caller — the miner and eth_simulateV1 via FinalizeAndAssemble, or historical
+// state regeneration via Finalize — passes a plain state and must not fire the
+// node-wide live tracer: those run outside the import goroutine, and invoking
+// the singleton live tracer concurrently corrupts its state and can crash the
+// node.
+func (c *Bor) systemTxVMConfig(state vm.StateDB) vm.Config {
+	cfg := c.vmConfig
+	if hooked, ok := state.(stateTracingHooks); ok {
+		cfg.Tracer = hooked.Hooks()
+	} else {
+		cfg.Tracer = nil
+	}
+
+	return cfg
+}
+
 func (c *Bor) checkAndCommitSpan(
 	state vm.StateDB,
 	header *types.Header,
@@ -1907,7 +1935,7 @@ func (c *Bor) FetchAndCommitSpan(
 		)
 	}
 
-	return c.spanner.CommitSpan(ctx, minSpan, validators, producers, state, header, chain, c.vmConfig)
+	return c.spanner.CommitSpan(ctx, minSpan, validators, producers, state, header, chain, c.systemTxVMConfig(state))
 }
 
 // CommitStates commit states
@@ -2018,6 +2046,8 @@ func (c *Bor) CommitStates(
 
 	var gasUsed uint64
 
+	vmConfig := c.systemTxVMConfig(state)
+
 	for _, eventRecord := range eventRecords {
 		if eventRecord.ID <= lastStateID {
 			continue
@@ -2063,7 +2093,7 @@ func (c *Bor) CommitStates(
 
 		// Receipt construction expects the receiver call to emit at least one log.
 		// A receiver without code can complete without producing one.
-		gasUsed, err = c.GenesisContractsClient.CommitState(eventRecord, state, header, chain, c.vmConfig)
+		gasUsed, err = c.GenesisContractsClient.CommitState(eventRecord, state, header, chain, vmConfig)
 		if err != nil {
 			return nil, err
 		}

--- a/consensus/bor/vmconfig_test.go
+++ b/consensus/bor/vmconfig_test.go
@@ -1,0 +1,117 @@
+package bor
+
+import (
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/consensus/bor/clerk"
+	"github.com/ethereum/go-ethereum/consensus/bor/statefull"
+	"github.com/ethereum/go-ethereum/consensus/bor/valset"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/tracing"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+)
+
+// TestSystemTxVMConfig verifies that system transactions (span commits and
+// state-sync events) are traced only when the caller traces the state they
+// are applied to. The node-wide live tracer stored in c.vmConfig must never
+// leak into contexts that pass a plain state (miner and eth_simulateV1 via
+// FinalizeAndAssemble, historical state regeneration via Finalize): those run
+// outside the import goroutine, and invoking the singleton live tracer
+// concurrently corrupts it.
+func TestSystemTxVMConfig(t *testing.T) {
+	t.Parallel()
+
+	liveTracer := &tracing.Hooks{
+		OnEnter: func(depth int, typ byte, from, to common.Address, input []byte, gas uint64, value *big.Int) {
+			t.Error("live tracer must not be invoked for untraced states")
+		},
+	}
+	c := &Bor{vmConfig: vm.Config{Tracer: liveTracer, NoBaseFee: true}}
+
+	plainState, err := state.New(types.EmptyRootHash, state.NewDatabaseForTesting())
+	require.NoError(t, err)
+
+	// A plain state (regeneration, miner, eth_simulateV1) must not get the
+	// live tracer, but keeps the rest of the config.
+	cfg := c.systemTxVMConfig(plainState)
+	require.Nil(t, cfg.Tracer)
+	require.True(t, cfg.NoBaseFee)
+
+	// A hooked state (canonical import with a live tracer) keeps being traced
+	// with the hooks that trace the state itself.
+	importHooks := &tracing.Hooks{}
+	cfg = c.systemTxVMConfig(state.NewHookedState(plainState, importHooks))
+	require.Same(t, importHooks, cfg.Tracer)
+}
+
+// capturingGenesisContract records the vm.Config each CommitState call receives.
+type capturingGenesisContract struct {
+	lastStateID uint64
+	captured    []vm.Config
+}
+
+func (m *capturingGenesisContract) CommitState(event *clerk.EventRecordWithTime, state vm.StateDB, header *types.Header, chCtx statefull.ChainContext, vmCfg vm.Config) (uint64, error) {
+	m.captured = append(m.captured, vmCfg)
+	return 0, nil
+}
+
+func (m *capturingGenesisContract) LastStateId(st *state.StateDB, number uint64, hash common.Hash) (*big.Int, error) {
+	return big.NewInt(int64(m.lastStateID)), nil
+}
+
+// TestCommitStates_SystemTxTracer asserts end to end through CommitStates that
+// state-sync system transactions receive the tracer of the state they mutate:
+// the hooks tracing the state during canonical import, and no tracer at all
+// for plain states (miner and eth_simulateV1 via FinalizeAndAssemble,
+// historical state regeneration via Finalize) — never the node-wide live
+// tracer stored in c.vmConfig.
+func TestCommitStates_SystemTxTracer(t *testing.T) {
+	t.Parallel()
+
+	addr1 := common.HexToAddress("0x1")
+	sp := &fakeSpanner{vals: []*valset.Validator{{Address: addr1, VotingPower: 1}}}
+
+	now := time.Now()
+	chain, b := newChainAndBorForTest(t, sp, indoreBorConfig(), true, addr1, uint64(now.Unix()))
+
+	// The node-wide live tracer configured at startup: must never reach system txs.
+	b.vmConfig = vm.Config{Tracer: &tracing.Hooks{}, NoBaseFee: true}
+
+	gc := &capturingGenesisContract{lastStateID: 0}
+	b.GenesisContractsClient = gc
+	b.SetHeimdallClient(&mockHeimdallClient{
+		events: []*clerk.EventRecordWithTime{
+			{
+				EventRecord: clerk.EventRecord{ID: 1, Contract: common.HexToAddress("0x1001"), Data: []byte{0x01}, ChainID: "1"},
+				Time:        now.Add(-10 * time.Second),
+			},
+		},
+	})
+
+	genesis := chain.HeaderChain().GetHeaderByNumber(0)
+	header := &types.Header{Number: big.NewInt(16), ParentHash: genesis.Hash(), Time: uint64(now.Unix())}
+	cx := statefull.ChainContext{Chain: chain.HeaderChain(), Bor: b}
+
+	// Plain state (regeneration, miner, eth_simulateV1): no tracer, rest of the
+	// engine config preserved.
+	_, err := b.CommitStates(newStateDBForTest(t, genesis.Root), header, cx)
+	require.NoError(t, err)
+	require.Len(t, gc.captured, 1)
+	require.Nil(t, gc.captured[0].Tracer)
+	require.True(t, gc.captured[0].NoBaseFee)
+
+	// Hooked state (canonical import with a live tracer): traced with the hooks
+	// tracing the state itself.
+	gc.captured = nil
+	importHooks := &tracing.Hooks{}
+	_, err = b.CommitStates(state.NewHookedState(newStateDBForTest(t, genesis.Root), importHooks), header, cx)
+	require.NoError(t, err)
+	require.Len(t, gc.captured, 1)
+	require.Same(t, importHooks, gc.captured[0].Tracer)
+}

--- a/core/state/statedb_hooked.go
+++ b/core/state/statedb_hooked.go
@@ -313,3 +313,8 @@ func (s *hookedStateDB) Logs() []*types.Log {
 func (s *hookedStateDB) Inner() *StateDB {
 	return s.inner
 }
+
+// Hooks returns the tracing hooks this state emits to.
+func (s *hookedStateDB) Hooks() *tracing.Hooks {
+	return s.hooks
+}


### PR DESCRIPTION
## Problem

Bor system transactions (span commits and state-sync events) are always executed with `c.vmConfig` — the `vm.Config` the consensus engine captured at startup. When a live tracer is configured (`--vmtrace`), that config carries the node-wide **singleton** tracer hooks, so *every* caller of `Finalize` / `FinalizeAndAssemble` fires them, not just canonical block import:

* **`eth_simulateV1`** → `simulator.processBlock` → `FinalizeAndAssemble` → `CommitStates` runs **on an RPC goroutine** whenever the simulated block number is a sprint start.
* **`debug_trace*` historical state regeneration** replays ancestor blocks via `StateProcessor.Process(..., vm.Config{}, ...)` → `Finalize`, which still commits system transactions with the live tracer despite the caller's empty config.

Live tracer hooks are stateful and single-threaded by contract (they are invoked serially during import — see also the concurrency note on `WrapStateSyncHooks`). Invoking them concurrently from RPC goroutines corrupts the tracer and the tracing journal.

**Observed in production** (bor v2.9.0, Polygon mainnet full nodes serving `eth_simulateV1` traffic with a live tracer): within milliseconds at a sprint-start block,

1. the simulate goroutine panics in the shared tracing journal — `RPC method eth_simulateV1 crashed: runtime error: slice bounds out of range [:-1]` in `journal.popRevision` (recovered by the RPC layer, leaving the shared tracer corrupted), then
2. the import goroutine panics inside the live tracer on the corrupted state and takes the node down.

All observed crash blocks were sprint starts (`number % 16 == 0`), matching the `IsSprintStart` gate in front of `checkAndCommitSpan`/`CommitStates`. Identically configured nodes receiving no `eth_simulateV1` traffic never crashed.

## Fix

Derive the system-transaction tracer from the **state being mutated** instead of `c.vmConfig`:

* Canonical import passes a hooked state (`state.NewHookedState`) when a live tracer is configured — system transactions there keep being traced with the same hooks as the rest of the block.
* Plain states — the miner and `eth_simulateV1` via `FinalizeAndAssemble` (which takes a concrete `*state.StateDB`), and historical state regeneration via `Finalize` — now run system transactions untraced, matching the (empty) config those callers execute the rest of the block with.

This adds an exported `Hooks()` accessor on `state.hookedStateDB` and a `systemTxVMConfig` helper on `Bor`, used at the two `c.vmConfig` call sites (`FetchAndCommitSpan` → `CommitSpan`, and `CommitStates` → `CommitState`).

## Testing

* `TestSystemTxVMConfig` verifies the tracer is stripped for plain states (with the rest of the config preserved) and taken from the hooked state during traced import.
* `go test ./consensus/bor/ ./core/state/` passes.