### PR TITLE
rpc: fix rpc_ep_workers_http being stopped on first request

### DIFF
--- a/rpc/client.go
+++ b/rpc/client.go
@@ -124,6 +124,9 @@ func (c *Client) newClientConn(conn ServerCodec) *clientConn {
 }
 
 func (cc *clientConn) close(err error, inflightReq *requestOp) {
+	// The client-side pool is per-connection (created in newClientConn), so it
+	// is owned here and must be stopped to release its metric goroutine.
+	cc.handler.executionPool.Stop()
 	cc.handler.close(err, inflightReq)
 	cc.codec.close()
 }

--- a/rpc/handler.go
+++ b/rpc/handler.go
@@ -334,7 +334,12 @@ func (h *handler) close(err error, inflightReq *requestOp) {
 	h.callWG.Wait()
 	h.cancelRoot()
 	h.cancelServerSubscriptions(err)
-	h.executionPool.Stop()
+
+	// The execution pool is deliberately not stopped here. On the server side
+	// it is shared across all handlers and owned by Server, which stops it in
+	// Server.Stop(); stopping it per-handler would kill the shared pool's
+	// metric goroutine on the first request (regression introduced in #1005).
+	// On the client side the per-connection pool is stopped by clientConn.close.
 }
 
 // addRequestOp registers a request operation.


### PR DESCRIPTION
## Summary

  The server-side HTTP RPC execution pool is shared across all handlers. PR #1005
  added `executionPool.Stop()` to `handler.close()`, so the first HTTP request stops
  the shared pool's metric-reporting goroutine before it ever ticks. As a result
  `rpc_ep_workers_http` (and its `rpc_ep_queue_http` / `rpc_ep_processed_http`
  siblings) is never registered.

  ## Fix

  - Remove `h.executionPool.Stop()` from `handler.close()` — the server pool is
    already stopped by `Server.Stop()`.
  - Add `cc.handler.executionPool.Stop()` to `clientConn.close()` — preserves
    PR #1005's goroutine-leak fix for the client, where the pool is per-connection.
