### PR TITLE
tests/bor: harden test peering against simultaneous-connect collisions

### DIFF
--- a/tests/bor/helper.go
+++ b/tests/bor/helper.go
@@ -863,23 +863,18 @@ func connectAndWaitForPeers(t *testing.T, a, b *node.Node) {
 	}
 	// Dial from one side only: mutual AddPeer invites simultaneous-connect
 	// collisions where each server can drop the other's inbound connection
-	// as a duplicate of its own in-flight dial, and with aligned retry
-	// backoff the collision can repeat until the deadline.
+	// as a duplicate of its own in-flight dial, and because failed dials
+	// enter the dialer's per-node history (checkDial: errRecentlyDialed,
+	// ~35s) aligned retries can keep colliding until the deadline. A single
+	// static dial can't collide, and the scheduler retries it on its own
+	// after each history expiry.
 	a.Server().AddPeer(b.Server().Self())
-	redial := time.NewTicker(10 * time.Second)
-	defer redial.Stop()
 	for a.Server().PeerCount() == 0 || b.Server().PeerCount() == 0 {
 		select {
 		case <-deadline:
 			t.Fatalf("nodes failed to peer within deadline: peers a=%d b=%d (a=%s b=%s)",
 				a.Server().PeerCount(), b.Server().PeerCount(),
 				a.Server().Self(), b.Server().Self())
-		case <-redial.C:
-			// Clear the static-dial entry and re-add it so the next dial is
-			// scheduled fresh instead of waiting out the dialer's failure
-			// backoff with a possibly stale endpoint.
-			a.Server().RemovePeer(b.Server().Self())
-			a.Server().AddPeer(b.Server().Self())
 		default:
 			time.Sleep(250 * time.Millisecond)
 		}

--- a/tests/bor/helper.go
+++ b/tests/bor/helper.go
@@ -861,13 +861,25 @@ func connectAndWaitForPeers(t *testing.T, a, b *node.Node) {
 			time.Sleep(50 * time.Millisecond)
 		}
 	}
+	// Dial from one side only: mutual AddPeer invites simultaneous-connect
+	// collisions where each server can drop the other's inbound connection
+	// as a duplicate of its own in-flight dial, and with aligned retry
+	// backoff the collision can repeat until the deadline.
 	a.Server().AddPeer(b.Server().Self())
-	b.Server().AddPeer(a.Server().Self())
+	redial := time.NewTicker(10 * time.Second)
+	defer redial.Stop()
 	for a.Server().PeerCount() == 0 || b.Server().PeerCount() == 0 {
 		select {
 		case <-deadline:
-			t.Fatalf("nodes failed to peer within deadline: peers a=%d b=%d",
-				a.Server().PeerCount(), b.Server().PeerCount())
+			t.Fatalf("nodes failed to peer within deadline: peers a=%d b=%d (a=%s b=%s)",
+				a.Server().PeerCount(), b.Server().PeerCount(),
+				a.Server().Self(), b.Server().Self())
+		case <-redial.C:
+			// Clear the static-dial entry and re-add it so the next dial is
+			// scheduled fresh instead of waiting out the dialer's failure
+			// backoff with a possibly stale endpoint.
+			a.Server().RemovePeer(b.Server().Self())
+			a.Server().AddPeer(b.Server().Self())
 		default:
 			time.Sleep(250 * time.Millisecond)
 		}


### PR DESCRIPTION
## Summary

Fixes the `nodes failed to peer within deadline: peers a=0 b=0` flake in the `TestPipelinedImportSRC_*` integration tests, which hit twice on 2026-08-24 — once on the develop push run for #2180's merge commit (`TestPipelinedImportSRC_BasicImport`) and once on #2368's PR run (`TestPipelinedImportSRC_WithTransactions`), both on busy runners in the same hour.

Root cause: `connectAndWaitForPeers` issued `AddPeer` from **both** sides simultaneously. Two servers dialing each other concurrently can each drop the other's inbound connection as a duplicate of their own in-flight dial, and with aligned retry backoff the collision can repeat until the deadline expires. A stuck dial state also had no reset path — one bad first exchange could consume the full 120s.

Fix (test-only, 15-line diff):
- dial from one side only — a single connection satisfies `PeerCount > 0` on both ends and removes the collision class entirely
- (dropped after review: a 10s redial ticker — the dial scheduler's per-node history isn't clearable via RemovePeer/AddPeer and the scheduler already retries static targets after each ~35s history expiry, so the ticker added nothing)
- include both enodes in the timeout message for future diagnosis

## Executed tests

Both previously-flaked tests (`TestPipelinedImportSRC_BasicImport`, `TestPipelinedImportSRC_WithTransactions`) pass 3× consecutively with the change (6/6 runs, ~45s each — no deadline burn).

## Rollout notes

Test-only; no client code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
