### PR TITLE
core, miner: fix nightly pipeline race failures

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -3860,7 +3860,7 @@ func (bc *BlockChain) insertChainWithWitnesses(chain types.Blocks, setHead bool,
 
 		// BOR state sync feed related changes
 		bc.stateSyncMu.RLock()
-		for _, data := range bc.GetStateSync() {
+		for _, data := range bc.getStateSyncLocked() {
 			bc.stateSyncFeed.Send(StateSyncEvent{Data: data})
 		}
 		bc.stateSyncMu.RUnlock()
@@ -5033,7 +5033,7 @@ func (bc *BlockChain) emitPostWriteEvents(block *types.Block, receipts []*types.
 	}
 	bc.chainHeadFeed.Send(ChainHeadEvent{Header: block.Header()})
 	bc.stateSyncMu.RLock()
-	for _, data := range bc.GetStateSync() {
+	for _, data := range bc.getStateSyncLocked() {
 		bc.stateSyncFeed.Send(StateSyncEvent{Data: data})
 	}
 	bc.stateSyncMu.RUnlock()
@@ -5959,7 +5959,7 @@ func (bc *BlockChain) collectPrevImportSRCIfAny(block *types.Block, parent *type
 func (bc *BlockChain) emitStateSyncFeed() {
 	bc.stateSyncMu.RLock()
 	defer bc.stateSyncMu.RUnlock()
-	for _, data := range bc.GetStateSync() {
+	for _, data := range bc.getStateSyncLocked() {
 		bc.stateSyncFeed.Send(StateSyncEvent{Data: data})
 	}
 }

--- a/core/blockchain_pipeline_lifecycle_test.go
+++ b/core/blockchain_pipeline_lifecycle_test.go
@@ -108,6 +108,49 @@ func TestEmitQueuedStateSyncFeed(t *testing.T) {
 	require.Same(t, data, (<-events).Data)
 }
 
+func TestGetStateSyncLockedWithQueuedWriter(t *testing.T) {
+	chain, _, _ := newPipelineHelperChain(t)
+	data := &types.StateSyncData{ID: 99}
+	chain.SetStateSync([]*types.StateSyncData{data})
+	require.Equal(t, []*types.StateSyncData{data}, chain.GetStateSync())
+
+	chain.stateSyncMu.RLock()
+	lockHeld := true
+	defer func() {
+		if lockHeld {
+			chain.stateSyncMu.RUnlock()
+		}
+	}()
+
+	writerDone := make(chan struct{})
+	go func() {
+		defer close(writerDone)
+		chain.SetStateSync(nil)
+	}()
+	require.Eventually(t, func() bool {
+		if chain.stateSyncMu.TryRLock() {
+			chain.stateSyncMu.RUnlock()
+			return false
+		}
+		return true
+	}, 5*time.Second, time.Millisecond, "writer did not wait for state sync lock")
+
+	readDone := make(chan []*types.StateSyncData, 1)
+	go func() { readDone <- chain.getStateSyncLocked() }()
+	select {
+	case got := <-readDone:
+		require.Equal(t, []*types.StateSyncData{data}, got)
+	case <-time.After(5 * time.Second):
+		chain.stateSyncMu.RUnlock()
+		lockHeld = false
+		<-writerDone
+		t.Fatal("lock-held state sync read blocked behind a queued writer")
+	}
+	chain.stateSyncMu.RUnlock()
+	lockHeld = false
+	<-writerDone
+}
+
 func TestRunSRCComputeFailureBranches(t *testing.T) {
 	t.Run("panic is converted to an SRC error", func(t *testing.T) {
 		chain, _, blocks := newPipelineHelperChain(t)

--- a/core/blockchain_reader.go
+++ b/core/blockchain_reader.go
@@ -980,6 +980,11 @@ func (bc *BlockChain) SetStateSync(stateData []*types.StateSyncData) {
 func (bc *BlockChain) GetStateSync() []*types.StateSyncData {
 	bc.stateSyncMu.RLock()
 	defer bc.stateSyncMu.RUnlock()
+	return bc.getStateSyncLocked()
+}
+
+// getStateSyncLocked returns state sync data while stateSyncMu is held.
+func (bc *BlockChain) getStateSyncLocked() []*types.StateSyncData {
 	return bc.stateSyncData
 }
 

--- a/miner/pipeline_session_test.go
+++ b/miner/pipeline_session_test.go
@@ -36,7 +36,13 @@ func newPipelineWorkerFixture(t *testing.T, configure func(*params.ChainConfig))
 	t.Cleanup(func() { require.NoError(t, engine.Close()) })
 
 	w, backend, cleanup := newTestWorker(t, DefaultTestConfig(), &chainConfig, engine, rawdb.NewMemoryDatabase(), false, 0)
-	t.Cleanup(cleanup)
+	t.Cleanup(func() {
+		select {
+		case <-w.exitCh:
+		default:
+			cleanup()
+		}
+	})
 	return w, backend
 }
 
@@ -116,6 +122,7 @@ func TestPipelineSessionFailureAndExitBranches(t *testing.T) {
 	t.Run("non Bor engine rejects pipeline operations", func(t *testing.T) {
 		w, _, session := newPipelineSessionFixture(t, nil)
 		<-session.initialFillDone
+		w.close()
 		wrapped := &pipelineSealEngine{Engine: w.engine, seal: func(consensus.ChainHeaderReader, *types.Block, *stateless.Witness, chan<- *consensus.NewSealedBlockEvent, <-chan struct{}) error {
 			return nil
 		}}
@@ -279,6 +286,7 @@ func TestPipelineSessionAdditionalRecoveryBranches(t *testing.T) {
 
 	t.Run("inline broadcast returns seal error", func(t *testing.T) {
 		w, _, _ := newPipelineRequestFixture(t, nil)
+		w.close()
 		sealErr := errors.New("seal failed")
 		w.engine = &pipelineSealEngine{
 			Engine: w.engine,
@@ -317,13 +325,9 @@ func TestCommitPipelinedAdditionalBranches(t *testing.T) {
 
 	t.Run("worker exit cancels handoff", func(t *testing.T) {
 		w, _, req := newPipelineRequestFixture(t, nil)
+		w.close()
 		w.running.Store(true)
-		originalExit := w.exitCh
-		stopped := make(chan struct{})
-		close(stopped)
-		w.exitCh = stopped
 		w.speculativeWorkCh = make(chan *speculativeWorkReq)
-		t.Cleanup(func() { w.exitCh = originalExit })
 
 		require.NoError(t, w.commitPipelined(req.blockNEnv, time.Now()))
 	})
@@ -341,12 +345,8 @@ func TestSpecSessionMoreFailureBranches(t *testing.T) {
 
 	t.Run("initial setup requires grandparent", func(t *testing.T) {
 		w, _, req := newPipelineRequestFixture(t, nil)
+		w.close()
 		req.parentHeader.ParentHash = common.HexToHash("0xdead")
-		originalExit := w.exitCh
-		stopped := make(chan struct{})
-		close(stopped)
-		w.exitCh = stopped
-		t.Cleanup(func() { w.exitCh = originalExit })
 
 		require.False(t, newSpecSession(w, req).setupInitial())
 	})
@@ -396,6 +396,7 @@ func TestSpecSessionMoreFailureBranches(t *testing.T) {
 		finalHeader, flatDiff, syncData, ok := session.finalizeCurrent()
 		require.True(t, ok)
 
+		w.close()
 		prepareErr := errors.New("prepare failed")
 		w.engine = &pipelinePrepareEngine{
 			Engine: w.engine,
@@ -424,12 +425,8 @@ func TestSealCurrentAndAdvanceExitAndSealFailure(t *testing.T) {
 
 	t.Run("worker exit interrupts announce wait", func(t *testing.T) {
 		w, session, finalHeader, syncData, next := newPreparedSession(t)
+		w.close()
 		finalHeader.ActualTime = time.Now().Add(time.Hour)
-		originalExit := w.exitCh
-		stopped := make(chan struct{})
-		close(stopped)
-		w.exitCh = stopped
-		t.Cleanup(func() { w.exitCh = originalExit })
 
 		sealed, exitEarly, ok := session.sealCurrentAndAdvance(finalHeader, syncData, next)
 		require.False(t, ok)
@@ -439,6 +436,7 @@ func TestSealCurrentAndAdvanceExitAndSealFailure(t *testing.T) {
 
 	t.Run("inline seal error stops iteration", func(t *testing.T) {
 		w, session, finalHeader, syncData, next := newPreparedSession(t)
+		w.close()
 		sealErr := errors.New("seal failed")
 		w.engine = &pipelineSealEngine{
 			Engine: w.engine,

--- a/miner/pipeline_test.go
+++ b/miner/pipeline_test.go
@@ -311,7 +311,7 @@ func TestPipelineTimingAndChainHelpers(t *testing.T) {
 	defer borEngine.(*bor.Bor).Close()
 
 	w, backend, cleanup := newTestWorker(t, DefaultTestConfig(), &chainConfig, borEngine, rawdb.NewMemoryDatabase(), false, 0)
-	defer cleanup()
+	cleanup()
 
 	parent := backend.chain.CurrentHeader()
 	wrappedEngine := &pipelineSealEngine{


### PR DESCRIPTION
## Summary
Fixes the failures in [nightly race run 32804872411](https://github.com/0xPolygon/bor/actions/runs/32804872411) on the `develop` merge of [#2180](https://github.com/0xPolygon/bor/pull/2180).

The run had two root causes:

- A real Bor lock-ordering bug exposed by the new pipeline concurrency. Three state-sync feed paths held `stateSyncMu` for reading and then called `GetStateSync`, which tried to acquire the same read lock again. Once `SetStateSync` queued as a writer, Go's writer-preferring `RWMutex` blocked that nested read and stalled block production. The fix adds a lock-held accessor and uses it from all three already-locked paths. A regression test queues a writer and proves the lock-held read completes.
- Test-only data races introduced with the pipeline tests. Several tests replaced `worker.engine`, `worker.exitCh`, or `worker.speculativeWorkCh` after `newWorker` had started its background loops. The fix shuts the worker down before mutating those test fixtures and makes fixture cleanup tolerate that explicit shutdown. This covers all seven CI race reports and one additional engine-swap race reproduced locally.

The failures are not CI/infrastructure instability or external dependency failures. No recent open PR was found that addressed these failures.

## Executed tests
- `go test -race ./miner -run '^(TestPipelineSessionFailureAndExitBranches|TestPipelineSessionAdditionalRecoveryBranches|TestCommitPipelinedAdditionalBranches|TestSpecSessionMoreFailureBranches|TestSealCurrentAndAdvanceExitAndSealFailure|TestPipelineTimingAndChainHelpers)$' -count=1 -shuffle=1787631884337310962 -timeout=5m`
- `go test -race ./core -run '^Test(GetStateSyncLockedWithQueuedWriter|EmitQueuedStateSyncFeed|PipelinedStateSyncLogsAndEvents)$' -count=20 -timeout=5m`
- `go test -race ./miner -run '^TestConcurrentPrefetchAndBlockBuilding$' -count=5 -timeout=3m`
- `go test -race ./miner -shuffle=1787631884337310962 -count=1 -timeout=15m` (passed in 219.326s)
- `go test ./core ./miner -shuffle=1787631884337310962 -count=1 -timeout=15m` (`core` passed in 496.943s; isolated `miner` rerun passed in 219.802s)
- `make test-integration` (`tests/bor` passed in 636.310s with 76.7% coverage)
- `make lint` (0 issues)
- `go vet ./miner`
- Diffguard with 100% mutation sampling: 100% (1/1 killed); complexity and size checks passed.

## Rollout notes
Backward-compatible concurrency and test-harness fix. It does not change block contents, state-sync ordering, consensus rules, hardfork activation, configuration, or operator behavior.

The full local arm64 `go test -race ./core` run reached the 15-minute package limit in the exhaustive `TestV2WitnessRegenerationPipelinedSRCAllBlocks`; the reported CI run's unchanged `core` package passed in 828.558s, and the focused changed-path race tests passed 20 iterations. `go vet ./core` also retains the pre-existing lock-copy warning at `core/parallel_state_processor.go:335`. Diffguard's overall exit remains nonzero for its existing `core -> core` self-cycle report, despite the mutation, complexity, and size checks passing.
