### PR TITLE
fix: add actionable hints for chain out of sync errors (#2363)

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -224,7 +224,7 @@ var (
 	}
 )
 
-var app = flags.NewApp("the go-ethereum command line interface")
+var app = flags.NewApp("the go-ethereum command line interface. Check for updates at https://github.com/0xPolygon/bor/releases")
 
 func init() {
 	// Initialize the CLI app and start Geth

--- a/eth/bor_checkpoint_verifier.go
+++ b/eth/bor_checkpoint_verifier.go
@@ -67,7 +67,7 @@ func borVerify(ctx context.Context, eth *Ethereum, handler *ethHandler, start ui
 	head := currentBlock.Number.Uint64()
 
 	if head < end {
-		log.Debug(fmt.Sprintf("Current head block behind incoming %s block", str), "head", head, "end block", end)
+		log.Info(fmt.Sprintf("Current head block behind incoming %s block", str), "head", head, "end block", end, "hint", "Check for updates if sync is stalled.")
 		return hash, errChainOutOfSync
 	}
 

--- a/eth/handler_bor.go
+++ b/eth/handler_bor.go
@@ -49,9 +49,9 @@ func (h *ethHandler) handleWhitelistCheckpoint(ctx context.Context, checkpoint *
 	hash, err := verifier.verify(ctx, eth, h, checkpoint.StartBlock, checkpoint.EndBlock, checkpoint.RootHash.String()[2:], true)
 	if err != nil {
 		if errors.Is(err, errChainOutOfSync) {
-			log.Info("Whitelisting checkpoint deferred", "err", err)
+			log.Info("Whitelisting checkpoint deferred. Check for updates if sync is stalled.", "err", err)
 		} else {
-			log.Warn("Failed to whitelist checkpoint", "err", err)
+			log.Warn("Failed to whitelist checkpoint. Check for updates if sync is stalled.", "err", err)
 		}
 		return common.Hash{}, err
 	}
@@ -91,9 +91,9 @@ func (h *ethHandler) handleMilestone(ctx context.Context, eth *Ethereum, milesto
 	_, err := verifier.verify(ctx, eth, h, milestone.StartBlock, milestone.EndBlock, milestone.Hash.String()[2:], false)
 	if err != nil {
 		if errors.Is(err, errChainOutOfSync) {
-			log.Info("Whitelisting milestone deferred", "err", err)
+			log.Info("Whitelisting milestone deferred. Check for updates if sync is stalled.", "err", err)
 		} else {
-			log.Warn("Failed to whitelist milestone", "err", err)
+			log.Warn("Failed to whitelist milestone. Check for updates if sync is stalled.", "err", err)
 		}
 		h.downloader.UnlockSprint(milestone.EndBlock)
 	}


### PR DESCRIPTION
## Summary

Adds actionable update hints to chain out of sync messages and Bor checkpoint or milestone handling. This helps node operators identify stalled syncs and check for newer releases.

Fixes #2363.

## Tests

Reviewed the changed Go paths and verified formatting and diff scope. Full repository tests were not run in this sandbox.

## Rollout notes

This is an operator-facing logging change with no consensus or storage behavior changes.