### PR TITLE
build: increase race-test package timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ test-txpool-race:
 	$(GOTEST) -run=TestPoolMiningDataRaces --timeout 600m -race -v ./core/
 
 test-race:
-	$(GOTEST) --timeout 15m -race -shuffle=on $(TESTALL)
+	$(GOTEST) --timeout 45m -race -shuffle=on $(TESTALL)
 
 gocovmerge-deps:
 	$(GOBUILD) -o $(GOBIN)/gocovmerge github.com/wadey/gocovmerge


### PR DESCRIPTION
## Summary

Fixes the false failure in [nightly race run 33230997343](https://github.com/0xPolygon/bor/actions/runs/33230997343). The run did not report a data race: the `core` package reached its `15m` package timeout while `TestHeaderVerificationLoop/InvalidHeaderRewind` was in an expected ticker wait. The identical `develop` SHA passed on August 28, 30, and 31; the two adjacent successful runs took 824.865s and 824.998s for `core`, leaving only about 75 seconds of headroom.

The race timeout has been unchanged since 2022 while the `core` test suite has grown substantially. This change increases the per-package `test-race` timeout from `15m` to `45m`. The nightly workflow retains its existing 120-minute job timeout, so genuinely stuck runs remain bounded and fail.

This is a CI/test-budget issue, not a Bor production bug, a recurrence of #2371, a data race, or an external dependency failure. No recent open PR was found that addresses this timeout.

## Executed tests

- `make -n test-race` (renders `--timeout 45m -race -shuffle=on`)
- `go test -race ./core -run '^TestHeaderVerificationLoop$' -shuffle=1787973602612528487 -count=1 -timeout=2m` (passed in 29.138s)
- `golangci-lint run --config ./.golangci.yml` (0 issues)
- `diffguard --base origin/develop --output json .` (no Go files in the diff)
- `git diff --check`

An exact-shuffle full `core` race run on local arm64 remained actively executing `TestV2WitnessRegenerationPipelinedSRCAllBlocks` when it reached a separate 30-minute local limit; it emitted no race report. The hosted x64 evidence is the relevant validation for this CI-only change: three of four same-SHA nightlies passed, including [the August 31 run](https://github.com/0xPolygon/bor/actions/runs/33353539434).

## Rollout notes

CI-only and backward compatible. No production, consensus, storage, configuration, or operator behavior changes. A genuinely stuck package can now take up to 30 minutes longer to emit its package-level timeout stack, but the workflow-level 120-minute cap remains unchanged.
