### PR TITLE
core/blockstm, core: exclude base-code senders from V2 nonce pre-compute; harden witness parity harness

### DIFF
--- a/core/blockstm/v2_executor.go
+++ b/core/blockstm/v2_executor.go
@@ -62,6 +62,8 @@ type V2SettleFn func(txIdx int, state V2TxState)
 // V2Env provides the execution environment for V2 BlockSTM.
 type V2Env interface {
 	BaseNonce(addr common.Address) uint64
+	// BaseCodeSize returns the size of addr's code at pre-block base state.
+	BaseCodeSize(addr common.Address) int
 	Execute(task V2Task, workerID int, incarnation int,
 		senderNonces map[common.Address]uint64,
 		coinbase common.Address,
@@ -200,21 +202,29 @@ func newV2ExecCtx(tasks []V2Task, env V2Env, coinbase common.Address,
 }
 
 // computeSenderNonces returns per-task per-sender pre-computed nonces for
-// same-sender chains (length >= 2). Tasks whose sender appears in any
-// tx's EIP-7702 auth list — whether earlier or later in the block — are
-// excluded from the pre-compute and fall through to PDB.GetNonce →
-// MVStore. We can't tell at scheduling time whether an auth-list entry
-// will be applied (apply-time check requires auth.nonce == account.nonce
-// and a valid signature on the current chainID), so any pre-bump we put
-// here would be wrong for failed auths and a SenderNonces hit
-// short-circuits PDB.GetNonce without recording a read — meaning
-// validation can never invalidate the stale value. The MVStore fallback
-// records reads, so validation re-executes the tx once an earlier
-// auth-bump (or its absence) lands in the store.
+// same-sender chains (length >= 2). The pre-compute is only sound when
+// nothing but the sender's own txs can move its nonce during the block,
+// because a SenderNonces hit short-circuits PDB.GetNonce without
+// recording a read — validation can never invalidate a stale value.
+// Two classes of sender are therefore excluded and fall through to the
+// MVStore-aware path, which records reads so validation re-executes the
+// tx once a mid-block nonce change (or its absence) lands in the store:
 //
-// Tasks with no chain and no auth-list interaction get nil — same as
-// the original optimisation, so PDB.GetNonce reads the base nonce
-// directly.
+//   - Senders appearing in any tx's EIP-7702 auth list — whether earlier
+//     or later in the block. The auth-list applier bumps authority nonces,
+//     and we can't tell at scheduling time whether an auth-list entry will
+//     be applied (apply-time check requires auth.nonce == account.nonce
+//     and a valid signature on the current chainID), so any pre-bump we
+//     put here would be wrong for failed auths.
+//
+//   - Senders carrying code at base state. Only a delegation designator
+//     is possible there for a valid sender (EIP-3607 bars other code), and
+//     a call into a delegated account runs the delegate code in the
+//     account's own frame — a CREATE inside it bumps the sender's nonce
+//     mid-block, invalidating any pre-computed chain positions after it.
+//
+// Tasks with no chain and no exclusion get nil — same as the original
+// optimisation, so PDB.GetNonce reads the base nonce directly.
 func computeSenderNonces(tasks []V2Task, env V2Env) []map[common.Address]uint64 {
 	// Any address that is an authority in any tx may have its nonce
 	// dynamically bumped by the auth-list applier. Don't pre-compute
@@ -233,12 +243,26 @@ func computeSenderNonces(tasks []V2Task, env V2Env) []map[common.Address]uint64 
 	chains := groupBySender(tasks, env)
 	out := make([]map[common.Address]uint64, len(tasks))
 	for sender, c := range chains {
-		if _, isAuth := authoritySet[sender]; isAuth {
-			continue
+		if precomputeSenderNonces(sender, c, authoritySet, env) {
+			assignSenderNonces(out, sender, c)
 		}
-		assignSenderNonces(out, sender, c)
 	}
 	return out
+}
+
+// precomputeSenderNonces reports whether sender's chain qualifies for the
+// pre-compute: length >= 2, not an EIP-7702 authority in this block, and no
+// code at base state. Chain length is checked first because it is free,
+// while the base-code lookup can hit disk and singleton senders (the common
+// case) should never pay for it.
+func precomputeSenderNonces(sender common.Address, c *senderChain, authoritySet map[common.Address]struct{}, env V2Env) bool {
+	if len(c.taskIdxs) < 2 {
+		return false
+	}
+	if _, isAuth := authoritySet[sender]; isAuth {
+		return false
+	}
+	return env.BaseCodeSize(sender) == 0
 }
 
 // senderChain is the per-sender precomputed nonce chain.

--- a/core/blockstm/v2_executor_test.go
+++ b/core/blockstm/v2_executor_test.go
@@ -46,6 +46,7 @@ type mockV2Env struct {
 }
 
 func (e *mockV2Env) BaseNonce(common.Address) uint64 { return 0 }
+func (e *mockV2Env) BaseCodeSize(common.Address) int { return 0 }
 func (e *mockV2Env) Execute(task V2Task, workerID int, incarnation int,
 	senderNonces map[common.Address]uint64, coinbase common.Address,
 	waitForTx func(int), waitForFinal func(int), deferWrites bool) V2TxState {
@@ -134,6 +135,7 @@ type timedMockV2Env struct {
 }
 
 func (e *timedMockV2Env) BaseNonce(common.Address) uint64 { return 0 }
+func (e *timedMockV2Env) BaseCodeSize(common.Address) int { return 0 }
 func (e *timedMockV2Env) Execute(task V2Task, workerID int, incarnation int,
 	senderNonces map[common.Address]uint64, coinbase common.Address,
 	waitForTx func(int), waitForFinal func(int), deferWrites bool) V2TxState {
@@ -234,6 +236,7 @@ func (s *panickingV2State) SetDeferMVWrites(bool)                   {}
 type panickingV2Env struct{ s *panickingV2State }
 
 func (e *panickingV2Env) BaseNonce(common.Address) uint64 { return 0 }
+func (e *panickingV2Env) BaseCodeSize(common.Address) int { return 0 }
 func (e *panickingV2Env) Execute(task V2Task, workerID int, incarnation int,
 	senderNonces map[common.Address]uint64, coinbase common.Address,
 	waitForTx func(int), waitForFinal func(int), deferWrites bool) V2TxState {
@@ -273,11 +276,18 @@ func (t *nonceMockTask) Sender() common.Address        { return t.sender }
 func (t *nonceMockTask) To() *common.Address           { return nil }
 func (t *nonceMockTask) Authorities() []common.Address { return t.auths }
 
-// nonceMockEnv reads BaseNonce from a per-address map.
-type nonceMockEnv struct{ nonces map[common.Address]uint64 }
+// nonceMockEnv reads BaseNonce and BaseCodeSize from per-address maps.
+type nonceMockEnv struct {
+	nonces    map[common.Address]uint64
+	codeSizes map[common.Address]int
+}
 
 func (e *nonceMockEnv) BaseNonce(addr common.Address) uint64 {
 	return e.nonces[addr]
+}
+
+func (e *nonceMockEnv) BaseCodeSize(addr common.Address) int {
+	return e.codeSizes[addr]
 }
 func (e *nonceMockEnv) Execute(V2Task, int, int, map[common.Address]uint64, common.Address, func(int), func(int), bool) V2TxState {
 	return nil
@@ -372,6 +382,27 @@ func TestComputeSenderNonces_ExcludesAuthorities(t *testing.T) {
 		}
 		if got := out[2][addrA]; got != 8 {
 			t.Errorf("tx2 SenderNonces[A] = %d, want 8", got)
+		}
+	})
+
+	// A sender delegated in an EARLIER block carries a designator at base
+	// state but appears in no auth list of this block, so authoritySet
+	// misses it. A CALL into it runs the delegate code in its own frame;
+	// a CREATE there bumps the sender's nonce mid-block, invalidating any
+	// pre-computed chain position after it. Excluding senders with
+	// base-state code routes them through the MVStore path instead.
+	t.Run("sender has base-state code: no publish", func(t *testing.T) {
+		tasks := []V2Task{
+			&nonceMockTask{idx: 0, sender: addrA},
+			&nonceMockTask{idx: 1, sender: addrA},
+		}
+		env := &nonceMockEnv{
+			nonces:    map[common.Address]uint64{addrA: 0},
+			codeSizes: map[common.Address]int{addrA: 23}, // ef0100 || 20-byte target
+		}
+		out := computeSenderNonces(tasks, env)
+		if out[0] != nil || out[1] != nil {
+			t.Errorf("sender has base code; want nil for both, got %v / %v", out[0], out[1])
 		}
 	})
 }

--- a/core/mainnet_witness_benchmark_test.go
+++ b/core/mainnet_witness_benchmark_test.go
@@ -317,7 +317,7 @@ func fetchAndCacheCode(addr common.Address, blockHex string, alchemyURL string) 
 	codeDir := filepath.Join(witnessDir, "codes")
 	os.MkdirAll(codeDir, 0755) //nolint:errcheck
 
-	cachePath := filepath.Join(codeDir, addr.Hex()+".bin")
+	cachePath := filepath.Join(codeDir, addr.Hex()+"-"+blockHex+".bin")
 	if data, err := os.ReadFile(cachePath); err == nil {
 		return data, nil
 	}
@@ -376,6 +376,9 @@ func prewarmCodes(diskdb ethdb.Database, witness *stateless.Witness, block *type
 		if err != nil {
 			return fmt.Errorf("fetching code for %s: %w", addr.Hex(), err)
 		}
+		if got := crypto.Keccak256Hash(code); got != codeHash {
+			return fmt.Errorf("code for %s at %s hashes to %x, account expects %x", addr.Hex(), parentBlockHex, got, codeHash)
+		}
 
 		if len(code) > 0 {
 			rawdb.WriteCode(diskdb, codeHash, code)
@@ -387,6 +390,15 @@ func prewarmCodes(diskdb ethdb.Database, witness *stateless.Witness, block *type
 	for _, tx := range block.Transactions() {
 		if tx.To() != nil {
 			if err := checkAndFetch(*tx.To()); err != nil {
+				return err
+			}
+		}
+		for _, auth := range tx.SetCodeAuthorizations() {
+			authority, err := auth.Authority()
+			if err != nil {
+				continue
+			}
+			if err := checkAndFetch(authority); err != nil {
 				return err
 			}
 		}
@@ -405,6 +417,18 @@ func newCodeCachingDB(codeDir string) *codeCachingDB {
 		Database: rawdb.NewMemoryDatabase(),
 		codeDir:  codeDir,
 	}
+}
+
+// supplementalCodes are EIP-7702 delegation designators that the dataset builder
+// missed: prewarmCodes originally fetched code only for tx.To() addresses, never
+// for authorities, and cached by address without a block dimension, so an
+// authority re-delegated between dataset blocks kept a stale designator. These
+// are the pre-block designators of authorities re-delegated in blocks 83014074,
+// 83014100 and 83020871, keyed by content hash like every other code blob.
+var supplementalCodes = []string{
+	"ef0100bee2f0de34362ff34a9189c2b2e67ed61a3300e9",
+	"ef010089248eec91b1436da005c405eb5fbcb0d0088e1e",
+	"ef0100879a23a785796bfca1d22f48c91818e1157a01b4",
 }
 
 func (db *codeCachingDB) loadCodesFromDisk() error {
@@ -441,6 +465,10 @@ func (db *codeCachingDB) loadCodesFromDisk() error {
 			codeHash := crypto.Keccak256Hash(code)
 			rawdb.WriteCode(db.Database, codeHash, code)
 		}
+	}
+	for _, hexCode := range supplementalCodes {
+		code := common.FromHex(hexCode)
+		rawdb.WriteCode(db.Database, crypto.Keccak256Hash(code), code)
 	}
 	return nil
 }
@@ -598,6 +626,9 @@ func executeStatelessSerial(config *params.ChainConfig, block *types.Block, witn
 	res, err := processor.Process(block, db, vm.Config{}, author, context.Background())
 	if err != nil {
 		return common.Hash{}, common.Hash{}, nil, err
+	}
+	if err := db.Error(); err != nil {
+		return common.Hash{}, common.Hash{}, nil, fmt.Errorf("serial base read: %w", err)
 	}
 
 	receiptRoot := types.DeriveSha(res.Receipts, trie.NewStackTrie(nil))
@@ -1093,7 +1124,8 @@ func runConsistencyCheck(t *testing.T, blocks []testBlockData, diskdb ethdb.Data
 
 		serialState, serialReceipt, _, err := executeStatelessSerial(config, bd.block, bd.witness, &author, engine, diskdb)
 		if err != nil {
-			t.Logf("block %d (#%d) serial error (skipping): %v", blockNum, i, err)
+			t.Errorf("block %d (#%d): serial error: %v", blockNum, i, err)
+			failures++
 			continue
 		}
 
@@ -1710,7 +1742,8 @@ func runV2BlockSTMConsistency(t *testing.T, blocks []testBlockData, diskdb ethdb
 		serialState, serialReceiptRoot, serialResult, err := executeStatelessSerial(config, bd.block, bd.witness, &author, engine, diskdb)
 		serialDur := time.Since(tSerial)
 		if err != nil {
-			t.Logf("block %d (#%d) serial error (skipping): %v", blockNum, i, err)
+			t.Errorf("block %d (#%d): serial error: %v", blockNum, i, err)
+			failures++
 			continue
 		}
 
@@ -1760,6 +1793,15 @@ func runV2BlockSTMConsistency(t *testing.T, blocks []testBlockData, diskdb ethdb
 		store := blockstm.NewMVStore()
 		bals := blockstm.NewMVBalanceStore()
 		result := ExecuteV2BlockSTM(context.Background(), tasks, readBase, store, bals, blockContext, bd.block.Hash(), vm.Config{}, config, bd.block.GasLimit(), numWorkers, finalDB, nil)
+		// A base read failure makes V2 drop the tx at settlement, so the root
+		// comparison below would report a misleading mismatch. Surface it as
+		// what it is: incomplete state (usually a code blob missing from the
+		// testdata archive).
+		if result.ReadErr != nil {
+			t.Errorf("block %d (#%d): v2 base read error: %v", blockNum, i, result.ReadErr)
+			failures++
+			continue
+		}
 
 		engine.Finalize(nil, bd.block.Header(), finalDB, bd.block.Body(), nil)
 		v2State := finalDB.IntermediateRoot(config.IsEIP158(bd.block.Number()))

--- a/core/parallel_state_processor.go
+++ b/core/parallel_state_processor.go
@@ -592,6 +592,10 @@ func (e *v2Env) BaseNonce(addr common.Address) uint64 {
 	return e.base.GetNonce(addr)
 }
 
+func (e *v2Env) BaseCodeSize(addr common.Address) int {
+	return e.base.GetCodeSize(addr)
+}
+
 // Shared closures — allocated once, reused across all workers.
 var sharedTransferLogFn = state.TransferLogFn(func(db *state.StateDB, sender, recipient common.Address, amount, input1, input2, output1, output2 *big.Int) {
 	AddTransferLog(db, sender, recipient, amount, input1, input2, output1, output2)

--- a/core/state/v2_executor_differential_test.go
+++ b/core/state/v2_executor_differential_test.go
@@ -92,6 +92,11 @@ func (e *exEnv) BaseNonce(addr common.Address) uint64 {
 	return nonce
 }
 
+func (e *exEnv) BaseCodeSize(addr common.Address) int {
+	size, _ := e.safeBase.GetCodeSize(addr)
+	return size
+}
+
 func (e *exEnv) acquire(idx int) *ParallelStateDB {
 	e.poolMu.Lock()
 	defer e.poolMu.Unlock()

--- a/core/v2_delegated_sender_nonce_test.go
+++ b/core/v2_delegated_sender_nonce_test.go
@@ -1,0 +1,122 @@
+package core
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/sha256"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/blockstm"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/triedb"
+)
+
+func delegatedSenderKey(tag byte) *ecdsa.PrivateKey {
+	seed := sha256.Sum256([]byte{tag, 0x01})
+	k, err := crypto.ToECDSA(seed[:])
+	if err != nil {
+		panic(err)
+	}
+	return k
+}
+
+// TestV2_DelegatedSenderNonceParity guards the parallel/serial parity property
+// for a sender that carries an EIP-7702 delegation designator installed in an
+// EARLIER block. Such a sender appears in no authorization list of the current
+// block, so computeSenderNonces' auth-list scan misses it. A CALL into the
+// delegated account runs the delegate code in the account's own frame; a CREATE
+// there bumps the sender's nonce mid-block. Pre-computing SenderNonces for that
+// sender would hand a later same-sender tx a stale nonce that BlockSTM V2 would
+// accept while the serial processor rejects it with "nonce too low" — a
+// per-node race outcome and thus a consensus split.
+//
+// With the base-state-code exclusion, V2 routes the sender through the
+// MVStore-aware nonce path and rejects the block exactly as serial does.
+func TestV2_DelegatedSenderNonceParity(t *testing.T) {
+	keyA := delegatedSenderKey(1) // delegated EOA, sends two txs in the block
+	keyB := delegatedSenderKey(2) // pokes A's delegate code via a plain CALL
+	addrA := crypto.PubkeyToAddress(keyA.PublicKey)
+	addrB := crypto.PubkeyToAddress(keyB.PublicKey)
+	// delegate target runtime: PUSH1 0; PUSH1 0; PUSH1 0; CREATE; POP; STOP
+	target := common.HexToAddress("0x00000000000000000000000000000000000d1e6a")
+	createCode := common.FromHex("600060006000f05000")
+	sink := common.HexToAddress("0x00000000000000000000000000000000000051f5")
+
+	cfg := fuzzChainConfig
+	bal, _ := new(big.Int).SetString("1000000000000000000000", 10)
+	// A carries the delegation designator at base state (installed earlier).
+	deleg := append([]byte{0xef, 0x01, 0x00}, target.Bytes()...)
+
+	gspec := &Genesis{
+		Config: cfg,
+		Alloc: types.GenesisAlloc{
+			addrA:  {Balance: bal, Code: deleg},
+			addrB:  {Balance: bal},
+			target: {Balance: common.Big0, Code: createCode},
+		},
+		GasLimit: 30_000_000,
+	}
+
+	memdb := rawdb.NewMemoryDatabase()
+	tdb := triedb.NewDatabase(memdb, triedb.HashDefaults)
+	genesis := gspec.MustCommit(memdb, tdb)
+
+	signer := types.LatestSigner(cfg)
+	mk := func(key *ecdsa.PrivateKey, nonce uint64, to common.Address, gas uint64) *types.Transaction {
+		return types.MustSignNewTx(key, signer, &types.DynamicFeeTx{
+			ChainID: cfg.ChainID, Nonce: nonce, To: &to, Gas: gas,
+			GasFeeCap: big.NewInt(1_000_000_000), GasTipCap: big.NewInt(1),
+			Value: big.NewInt(0),
+		})
+	}
+	txs := types.Transactions{
+		mk(keyA, 0, sink, 60_000),   // A@0
+		mk(keyB, 0, addrA, 200_000), // B -> A: delegate code runs CREATE, bumps A's nonce to 2
+		mk(keyA, 1, sink, 60_000),   // A@1: serial-invalid once A's nonce is 2
+	}
+
+	base, err := state.New(genesis.Root(), state.NewDatabase(tdb, nil))
+	if err != nil {
+		t.Fatalf("base state: %v", err)
+	}
+	finalDB, err := state.New(genesis.Root(), state.NewDatabase(tdb, nil))
+	if err != nil {
+		t.Fatalf("final state: %v", err)
+	}
+	blockCtx := vm.BlockContext{
+		CanTransfer: CanTransfer, Transfer: Transfer,
+		GetHash:     func(uint64) common.Hash { return common.Hash{} },
+		GasLimit:    gspec.GasLimit,
+		BlockNumber: big.NewInt(1),
+		Time:        1,
+		BaseFee:     big.NewInt(0),
+		Random:      &common.Hash{},
+	}
+	tasks := make([]V2Task, len(txs))
+	for i, tx := range txs {
+		m, err := TransactionToMessage(tx, signer, blockCtx.BaseFee)
+		if err != nil {
+			t.Fatalf("tx %d to message: %v", i, err)
+		}
+		tasks[i] = V2Task{Index: i, Tx: tx, Msg: m}
+	}
+
+	res := ExecuteV2BlockSTM(context.Background(), tasks, base, blockstm.NewMVStore(),
+		blockstm.NewMVBalanceStore(), blockCtx, common.Hash{}, vm.Config{}, cfg, gspec.GasLimit, 4, finalDB, nil)
+
+	// tx2 declares nonce 1, but A's real nonce is 2 after tx1's CREATE. V2 must
+	// reject it — matching the serial processor — rather than accept a stale
+	// pre-computed nonce.
+	if res.ExecErrIdx != 2 {
+		t.Fatalf("V2 accepted the delegated-sender block (ExecErrIdx=%d, err=%v); "+
+			"expected rejection at tx2 with a nonce error, matching the serial processor. "+
+			"computeSenderNonces handed out a stale pre-computed nonce for a base-state-delegated sender.",
+			res.ExecErrIdx, res.ExecErr)
+	}
+}


### PR DESCRIPTION
## Summary

**V2 BlockSTM nonce pre-compute.** `computeSenderNonces` pre-assigns nonces for senders with two or more txs in a block, on the assumption that only the sender's own txs (or an in-block EIP-7702 auth-list entry, already excluded) can move its nonce. A sender that carries a delegation designator at base state breaks that assumption: any CALL into it runs the delegate code in the sender's own frame, and a CREATE there bumps the sender's nonce mid-block. Because a `SenderNonces` hit short-circuits `PDB.GetNonce` without recording a read, validation could never correct the stale value, so V2 and the serial processor could disagree on such a block. Senders with base-state code are now excluded from the pre-compute and take the MVStore-aware nonce path (read recorded and validated), matching serial. Adds `V2Env.BaseCodeSize`, a `computeSenderNonces` unit case, and an integration test that runs a block with a base-state-delegated sender through V2.

**Witness parity harness and testdata.** While verifying with the 241-block mainnet witness suite, `TestV2BlockSTMAllBlocks` reported 3 stateRoot mismatches on `develop` (not on `master`). Root cause was a testdata gap exposed by #2180's base-read-error detection, not an executor bug: three blocks contain a SetCodeTx whose authority was already delegated, and the authority's pre-block designator blob was missing from `codes.tar.gz`. Serial reads the same blob, gets nil, and silently proceeds (the harness never checked `StateDB.Error`); V2 now surfaces `ReadErr` and drops the tx at settlement, which the harness misreported as a root mismatch. `master` passed only because its V2 had no read-error detection at all. Fixes: the V2 runner fails on `ReadErr`, `executeStatelessSerial` surfaces `StateDB.Error`, both runners count serial errors as failures, the dataset builder now fetches 7702 authorities, keys its cache by block, and verifies fetched code against the account hash, and the three missing designators are supplied (two reconstructed and keccak-verified from the dataset's own auth lists, one via a historical `eth_getCode`).

**Performance.** Measured on the 241 mainnet blocks (48,920 txs):

| | per block |
|---|---|
| existing scheduling cost (`BaseNonce`, every sender) | 3,247 µs |
| added cost (`BaseCodeSize`, multi-tx senders only) | 5.1 µs avg, 24 µs worst |
| typical V2 block time (4 workers) | ~90 ms |

The exclusion fired 0 times across 5,371 multi-tx senders, and V2 exec/vfail counts are unchanged within noise (58,306/9,386 on `develop` vs 57,797/8,877 here).

**diffguard** (`-base origin/develop`, mutation on): complexity max 9, sizes/churn/dead-code pass, mutation 100% (12/12). It also reports a `core -> core` dependency cycle, which is a tool artifact (the diff adds no import lines to any non-test file and Go rejects self-imports).

## Executed tests

- `BOR_BLOCKSTM_TEST=1 go test ./core/ -run TestV2BlockSTMAllBlocks` — 241/241 consistent, 0 failures (238/241 on `develop` before the testdata fix; 241/241 on `master`).
- `BOR_BLOCKSTM_TEST=1 go test ./core/ -run TestAllBlocksConsistency` — 241/241 consistent, 0 failures.
- `go test ./core/blockstm/` — full package.
- `go test ./core/ -run 'TestV2_DelegatedSenderNonceParity|TestV2_DelegateCodeReadConsistency|TestV2_ExistMissesPriorTxNonce|TestV2SerialParity_MetamorphicCreate2|TestV2ExecutorVsSerial_SeedCorpus'`.
- Before the fix, the new integration test's block is accepted by V2 and rejected by serial (`nonce too low`); after, both reject it identically.

## Rollout notes

Consensus-relevant: changes which senders V2 pre-computes nonces for, bringing V2 into line with the serial processor for delegated senders. No protocol, config, or storage change; backwards-compatible; no coordinated upgrade required. Nodes running `parallelevm.enable=true` (the default) should pick this up in the next release. Everything else in the PR is test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
