### PR TITLE
rpc, ethapi: release the execution slot while eth_sendRawTransactionSync waits

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -203,6 +203,7 @@ var (
 		utils.BatchResponseMaxSize,
 		utils.RPCTxSyncDefaultTimeoutFlag,
 		utils.RPCTxSyncMaxTimeoutFlag,
+		utils.RPCTxSyncMaxConcurrentFlag,
 	}
 
 	metricsFlags = []cli.Flag{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -681,6 +681,12 @@ var (
 		Value:    ethconfig.Defaults.TxSyncMaxTimeout,
 		Category: flags.APICategory,
 	}
+	RPCTxSyncMaxConcurrentFlag = &cli.IntFlag{
+		Name:     "rpc.txsync.maxconcurrent",
+		Usage:    "Maximum eth_sendRawTransactionSync calls waiting for a receipt at once (0 = no limit)",
+		Value:    ethconfig.Defaults.TxSyncMaxConcurrent,
+		Category: flags.APICategory,
+	}
 	// Authenticated RPC HTTP settings
 	AuthListenFlag = &cli.StringFlag{
 		Name:     "authrpc.addr",
@@ -1891,6 +1897,10 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 	if ctx.IsSet(RPCTxSyncDefaultTimeoutFlag.Name) {
 		cfg.TxSyncDefaultTimeout = ctx.Duration(RPCTxSyncDefaultTimeoutFlag.Name)
 	}
+	if ctx.IsSet(RPCTxSyncMaxConcurrentFlag.Name) {
+		cfg.TxSyncMaxConcurrent = ctx.Int(RPCTxSyncMaxConcurrentFlag.Name)
+	}
+
 	if ctx.IsSet(RPCTxSyncMaxTimeoutFlag.Name) {
 		cfg.TxSyncMaxTimeout = ctx.Duration(RPCTxSyncMaxTimeoutFlag.Name)
 	}

--- a/docs/cli/default_config.toml
+++ b/docs/cli/default_config.toml
@@ -121,6 +121,7 @@ devfakeauthor = false
   enabletrace = false
   "txsync.defaulttimeout" = "20s"
   "txsync.maxtimeout" = "1m0s"
+  "txsync.maxconcurrent" = 4096
   accept-preconf-tx = false
   accept-private-tx = false
   [jsonrpc.http]

--- a/docs/cli/server.md
+++ b/docs/cli/server.md
@@ -266,6 +266,8 @@ The ```bor server``` command runs the Bor client.
 
 - ```rpc.txsync.defaulttimeout```: Default timeout for eth_sendRawTransactionSync (e.g. 2s, 500ms) (default: 20s)
 
+- ```rpc.txsync.maxconcurrent```: Maximum eth_sendRawTransactionSync calls waiting for a receipt at once (0 = no limit) (default: 4096)
+
 - ```rpc.txsync.maxtimeout```: Maximum allowed timeout for eth_sendRawTransactionSync (e.g. 5m) (default: 1m0s)
 
 - ```ws```: Enable the WS-RPC server (default: false)

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -771,6 +771,10 @@ func (b *EthAPIBackend) RPCTxSyncMaxTimeout() time.Duration {
 	return b.eth.config.TxSyncMaxTimeout
 }
 
+func (b *EthAPIBackend) RPCTxSyncMaxConcurrent() int {
+	return b.eth.config.TxSyncMaxConcurrent
+}
+
 // Etherbase returns the address that mining rewards will be sent to.
 func (b *EthAPIBackend) Etherbase() (common.Address, error) {
 	return b.eth.Etherbase()

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -107,6 +107,7 @@ var Defaults = Config{
 	WitnessAPIEnabled:     false,
 	TxSyncDefaultTimeout:  20 * time.Second,
 	TxSyncMaxTimeout:      1 * time.Minute,
+	TxSyncMaxConcurrent:   4096,
 }
 
 //go:generate go run github.com/fjl/gencodec -type Config -formats toml -out gen_config.go
@@ -339,6 +340,12 @@ type Config struct {
 	// EIP-7966: eth_sendRawTransactionSync timeouts
 	TxSyncDefaultTimeout time.Duration `toml:",omitempty"`
 	TxSyncMaxTimeout     time.Duration `toml:",omitempty"`
+
+	// TxSyncMaxConcurrent caps calls waiting for an eth_sendRawTransactionSync
+	// receipt. Waiters don't hold an RPC execution slot, so this is what bounds
+	// them; size it for parked goroutines and chain-event subscribers, not for
+	// worker threads. 0 removes the cap.
+	TxSyncMaxConcurrent int `toml:",omitempty"`
 
 	// Sequence store integration (design docs/sequencer-bor.md). Role is
 	// derived, not configured: "producer" on a mining node (publishes the

--- a/eth/ethconfig/gen_config.go
+++ b/eth/ethconfig/gen_config.go
@@ -100,6 +100,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 		DisableBlindForkValidation           bool
 		MaxBlindForkValidationLimit          uint64
 		TxSyncDefaultTimeout                 time.Duration `toml:",omitempty"`
+		TxSyncMaxConcurrent                  int           `toml:",omitempty"`
 		TxSyncMaxTimeout                     time.Duration `toml:",omitempty"`
 		EnablePreconfs                       bool
 		EnablePrivateTx                      bool
@@ -188,6 +189,7 @@ func (c Config) MarshalTOML() (interface{}, error) {
 	enc.DisableBlindForkValidation = c.DisableBlindForkValidation
 	enc.MaxBlindForkValidationLimit = c.MaxBlindForkValidationLimit
 	enc.TxSyncDefaultTimeout = c.TxSyncDefaultTimeout
+	enc.TxSyncMaxConcurrent = c.TxSyncMaxConcurrent
 	enc.TxSyncMaxTimeout = c.TxSyncMaxTimeout
 	enc.EnablePreconfs = c.EnablePreconfs
 	enc.EnablePrivateTx = c.EnablePrivateTx
@@ -280,6 +282,7 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 		DisableBlindForkValidation           *bool
 		MaxBlindForkValidationLimit          *uint64
 		TxSyncDefaultTimeout                 *time.Duration `toml:",omitempty"`
+		TxSyncMaxConcurrent                  *int           `toml:",omitempty"`
 		TxSyncMaxTimeout                     *time.Duration `toml:",omitempty"`
 		EnablePreconfs                       *bool
 		EnablePrivateTx                      *bool
@@ -530,6 +533,9 @@ func (c *Config) UnmarshalTOML(unmarshal func(interface{}) error) error {
 	}
 	if dec.TxSyncDefaultTimeout != nil {
 		c.TxSyncDefaultTimeout = *dec.TxSyncDefaultTimeout
+	}
+	if dec.TxSyncMaxConcurrent != nil {
+		c.TxSyncMaxConcurrent = *dec.TxSyncMaxConcurrent
 	}
 	if dec.TxSyncMaxTimeout != nil {
 		c.TxSyncMaxTimeout = *dec.TxSyncMaxTimeout

--- a/eth/filters/IBackend.go
+++ b/eth/filters/IBackend.go
@@ -967,6 +967,20 @@ func (mr *MockBackendMockRecorder) RPCTxSyncDefaultTimeout() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RPCTxSyncDefaultTimeout", reflect.TypeOf((*MockBackend)(nil).RPCTxSyncDefaultTimeout))
 }
 
+// RPCTxSyncMaxConcurrent mocks base method.
+func (m *MockBackend) RPCTxSyncMaxConcurrent() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RPCTxSyncMaxConcurrent")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// RPCTxSyncMaxConcurrent indicates an expected call of RPCTxSyncMaxConcurrent.
+func (mr *MockBackendMockRecorder) RPCTxSyncMaxConcurrent() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RPCTxSyncMaxConcurrent", reflect.TypeOf((*MockBackend)(nil).RPCTxSyncMaxConcurrent))
+}
+
 // RPCTxSyncMaxTimeout mocks base method.
 func (m *MockBackend) RPCTxSyncMaxTimeout() time.Duration {
 	m.ctrl.T.Helper()

--- a/internal/cli/server/config.go
+++ b/internal/cli/server/config.go
@@ -518,6 +518,9 @@ type JsonRPCConfig struct {
 	TxSyncMaxTimeout    time.Duration `hcl:"-,optional" toml:"-"`
 	TxSyncMaxTimeoutRaw string        `hcl:"txsync.maxtimeout,optional" toml:"txsync.maxtimeout,optional"`
 
+	// Maximum eth_sendRawTransactionSync calls waiting for a receipt at once (0 = no limit)
+	TxSyncMaxConcurrent int `hcl:"txsync.maxconcurrent,optional" toml:"txsync.maxconcurrent,optional"`
+
 	// AcceptPreconfTx allows the RPC server to accept preconf transactions
 	AcceptPreconfTx bool `hcl:"accept-preconf-tx,optional" toml:"accept-preconf-tx,optional"`
 
@@ -1014,6 +1017,7 @@ func DefaultConfig() *Config {
 			EnableTrace:          false,
 			TxSyncDefaultTimeout: ethconfig.Defaults.TxSyncDefaultTimeout,
 			TxSyncMaxTimeout:     ethconfig.Defaults.TxSyncMaxTimeout,
+			TxSyncMaxConcurrent:  ethconfig.Defaults.TxSyncMaxConcurrent,
 			AcceptPreconfTx:      false,
 			AcceptPrivateTx:      false,
 			Http: &APIConfig{
@@ -1724,6 +1728,7 @@ func (c *Config) buildEth(stack *node.Node, accountManager *accounts.Manager) (*
 	n.RPCTxFeeCap = c.JsonRPC.TxFeeCap
 	n.TxSyncDefaultTimeout = c.JsonRPC.TxSyncDefaultTimeout
 	n.TxSyncMaxTimeout = c.JsonRPC.TxSyncMaxTimeout
+	n.TxSyncMaxConcurrent = c.JsonRPC.TxSyncMaxConcurrent
 
 	n.LogQueryLimit = c.JsonRPC.LogQueryLimit
 	n.RPCBlockRangeLimit = c.JsonRPC.RangeLimit

--- a/internal/cli/server/flags.go
+++ b/internal/cli/server/flags.go
@@ -798,6 +798,13 @@ func (c *Command) Flags(config *Config) *flagset.Flagset {
 		Default: c.cliConfig.JsonRPC.TxSyncMaxTimeout,
 		Group:   "JsonRPC",
 	})
+	f.IntFlag(&flagset.IntFlag{
+		Name:    "rpc.txsync.maxconcurrent",
+		Usage:   "Maximum eth_sendRawTransactionSync calls waiting for a receipt at once (0 = no limit)",
+		Value:   &c.cliConfig.JsonRPC.TxSyncMaxConcurrent,
+		Default: c.cliConfig.JsonRPC.TxSyncMaxConcurrent,
+		Group:   "JsonRPC",
+	})
 	f.BoolFlag(&flagset.BoolFlag{
 		Name:    "ipcdisable",
 		Usage:   "Disable the IPC-RPC server",

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -48,6 +48,7 @@ import (
 	"github.com/ethereum/go-ethereum/eth/gasestimator"
 	"github.com/ethereum/go-ethereum/eth/tracers/logger"
 	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/internal/ethapi/override"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/p2p"
@@ -63,6 +64,11 @@ const estimateGasErrorRatio = 0.015
 
 var errBlobTxNotSupported = errors.New("signing blob transactions not supported")
 var errSubClosed = errors.New("chain subscription closed")
+
+// txSyncCanonicalBackstop is how often a waiting sync call falls back to an
+// on-disk receipt lookup. Canonical arrival normally comes in as a chain event;
+// this only covers an event that carried no matching receipts.
+const txSyncCanonicalBackstop = time.Second
 
 // EthereumAPI provides an API to access Ethereum related information.
 type EthereumAPI struct {
@@ -1795,6 +1801,9 @@ type TransactionAPI struct {
 	b         Backend
 	nonceLock *AddrLocker
 	signer    types.Signer
+
+	// admission for calls parked in awaitReceipt; nil when unbounded.
+	txSyncWaiters chan struct{}
 }
 
 // returns block transactions along with state-sync transaction if present
@@ -1827,7 +1836,13 @@ func NewTransactionAPI(b Backend, nonceLock *AddrLocker) *TransactionAPI {
 	// The signer used by the API should always be the 'latest' known one because we expect
 	// signers to be backwards-compatible with old transactions.
 	signer := types.LatestSigner(b.ChainConfig())
-	return &TransactionAPI{b, nonceLock, signer}
+
+	api := &TransactionAPI{b: b, nonceLock: nonceLock, signer: signer}
+	if n := b.RPCTxSyncMaxConcurrent(); n > 0 {
+		api.txSyncWaiters = make(chan struct{}, n)
+	}
+
+	return api
 }
 
 // GetBlockTransactionCountByNumber returns the number of transactions in the block with the given block number.
@@ -2191,24 +2206,34 @@ func (api *TransactionAPI) currentBlobSidecarVersion() byte {
 	return types.BlobSidecarVersion0
 }
 
-// SendRawTransaction will add the signed transaction to the transaction pool.
-// The sender is responsible for signing the transaction and using the correct nonce.
-func (api *TransactionAPI) SendRawTransaction(ctx context.Context, input hexutil.Bytes) (common.Hash, error) {
+// decodeRawTransaction unmarshals a raw transaction, bringing a legacy blob
+// sidecar up to the version the current fork expects.
+func (api *TransactionAPI) decodeRawTransaction(input hexutil.Bytes) (*types.Transaction, error) {
 	tx := new(types.Transaction)
 	if err := tx.UnmarshalBinary(input); err != nil {
-		return common.Hash{}, err
+		return nil, err
 	}
 
 	// Convert legacy blob transaction proofs.
 	// TODO: remove in go-ethereum v1.17.x
-	if sc := tx.BlobTxSidecar(); sc != nil {
-		exp := api.currentBlobSidecarVersion()
-		if sc.Version == types.BlobSidecarVersion0 && exp == types.BlobSidecarVersion1 {
-			if err := sc.ToV1(); err != nil {
-				return common.Hash{}, fmt.Errorf("blob sidecar conversion failed: %v", err)
-			}
-			tx = tx.WithBlobTxSidecar(sc)
-		}
+	sc := tx.BlobTxSidecar()
+	if sc == nil || sc.Version != types.BlobSidecarVersion0 || api.currentBlobSidecarVersion() != types.BlobSidecarVersion1 {
+		return tx, nil
+	}
+
+	if err := sc.ToV1(); err != nil {
+		return nil, fmt.Errorf("blob sidecar conversion failed: %v", err)
+	}
+
+	return tx.WithBlobTxSidecar(sc), nil
+}
+
+// SendRawTransaction will add the signed transaction to the transaction pool.
+// The sender is responsible for signing the transaction and using the correct nonce.
+func (api *TransactionAPI) SendRawTransaction(ctx context.Context, input hexutil.Bytes) (common.Hash, error) {
+	tx, err := api.decodeRawTransaction(input)
+	if err != nil {
+		return common.Hash{}, err
 	}
 
 	hash, err := SubmitTransaction(ctx, api.b, tx)
@@ -2222,22 +2247,17 @@ func (api *TransactionAPI) SendRawTransaction(ctx context.Context, input hexutil
 // SendRawTransactionSync adds the signed transaction to the transaction pool and
 // waits for either a preconfirmation or canonical receipt until the timeout.
 func (api *TransactionAPI) SendRawTransactionSync(ctx context.Context, input hexutil.Bytes, timeoutMs *hexutil.Uint64) (map[string]interface{}, error) {
-	tx := new(types.Transaction)
-	if err := tx.UnmarshalBinary(input); err != nil {
+	tx, err := api.decodeRawTransaction(input)
+	if err != nil {
 		return nil, err
 	}
 
-	// Convert legacy blob transaction proofs.
-	// TODO: remove in go-ethereum v1.17.x
-	if sc := tx.BlobTxSidecar(); sc != nil {
-		exp := api.currentBlobSidecarVersion()
-		if sc.Version == types.BlobSidecarVersion0 && exp == types.BlobSidecarVersion1 {
-			if err := sc.ToV1(); err != nil {
-				return nil, fmt.Errorf("blob sidecar conversion failed: %v", err)
-			}
-			tx = tx.WithBlobTxSidecar(sc)
-		}
+	// Admit the waiter before submitting, so a rejection means the transaction
+	// was never accepted and the caller is free to retry or fall back.
+	if !api.enterTxSyncWait() {
+		return nil, errTxSyncBusy
 	}
+	defer api.leaveTxSyncWait()
 
 	ch := make(chan core.ChainEvent, 128)
 	sub := api.b.SubscribeChainEvent(ch)
@@ -2249,79 +2269,181 @@ func (api *TransactionAPI) SendRawTransactionSync(ctx context.Context, input hex
 	}
 	api.submitForPreconf(tx)
 
-	var (
-		maxTimeout     = api.b.RPCTxSyncMaxTimeout()
-		defaultTimeout = api.b.RPCTxSyncDefaultTimeout()
-		timeout        = defaultTimeout
-	)
-	if timeoutMs != nil && *timeoutMs > 0 {
-		req := time.Duration(*timeoutMs) * time.Millisecond
-		if req > maxTimeout {
-			timeout = maxTimeout
-		} else {
-			timeout = req
-		}
-	}
+	timeout := api.txSyncTimeout(timeoutMs)
+
 	receiptCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
-	preconfTick, stopPreconfPolling := api.preconfReceiptPolling()
-	defer stopPreconfPolling()
 
 	// Fast path.
 	if r := api.receiptIfAvailable(receiptCtx, hash); r != nil {
 		return r, nil
 	}
 
-	// Monitor the receipts
+	return api.awaitReceipt(receiptCtx, hash, timeout, sub, ch)
+}
+
+// txSyncTimeout resolves the caller's requested wait window against the node's
+// configured default and ceiling.
+func (api *TransactionAPI) txSyncTimeout(timeoutMs *hexutil.Uint64) time.Duration {
+	if timeoutMs == nil || *timeoutMs == 0 {
+		return api.b.RPCTxSyncDefaultTimeout()
+	}
+
+	return min(time.Duration(*timeoutMs)*time.Millisecond, api.b.RPCTxSyncMaxTimeout())
+}
+
+// awaitReceipt blocks until a preconfirmation or canonical receipt for hash
+// lands, or the wait window closes.
+//
+// The wait is idle, so it runs without a hold on the RPC execution pool: the
+// transaction is already submitted and every wake-up is a map lookup or a
+// channel receive. Holding a slot here would cap concurrent sync calls at the
+// pool size (ep-size, 40 per transport by default) and let a handful of them
+// starve every other call on that transport for a full wait window.
+// enterTxSyncWait is the bound that replaces it.
+func (api *TransactionAPI) awaitReceipt(
+	ctx context.Context,
+	hash common.Hash,
+	timeout time.Duration,
+	sub event.Subscription,
+	ch <-chan core.ChainEvent,
+) (map[string]interface{}, error) {
+	slot := rpc.ExecutionSlotFromContext(ctx)
+	slot.Release()
+
+	defer slot.Acquire()
+
+	preconfTick, stopPreconfPolling := api.preconfReceiptPolling()
+	defer stopPreconfPolling()
+
+	backstop := time.NewTicker(txSyncCanonicalBackstop)
+	defer backstop.Stop()
+
 	for {
 		select {
-		case <-receiptCtx.Done():
-			// If server-side wait window elapsed, return the structured timeout.
-			if errors.Is(receiptCtx.Err(), context.DeadlineExceeded) {
-				return nil, &txSyncTimeoutError{
-					msg:  fmt.Sprintf("The transaction was added to the transaction pool but wasn't processed in %v", timeout),
-					hash: hash,
-				}
-			}
-			return nil, receiptCtx.Err()
+		case <-ctx.Done():
+			return nil, txSyncWaitClosed(ctx, hash, timeout)
 
 		case err, ok := <-sub.Err():
-			if !ok {
-				return nil, errSubClosed
-			}
-			return nil, err
+			return nil, subscriptionFailure(err, ok)
 
 		case <-preconfTick:
-			if receipt := api.receiptIfAvailable(receiptCtx, hash); receipt != nil {
+			if receipt := api.pollReceipt(ctx, hash, false); receipt != nil {
 				return receipt, nil
 			}
 
-		case ev, ok := <-ch:
-			if !ok {
-				return nil, errSubClosed
+		case <-backstop.C:
+			if receipt := api.pollReceipt(ctx, hash, true); receipt != nil {
+				return receipt, nil
 			}
-			rs, txs := ev.Receipts, ev.Transactions
-			if len(rs) == 0 || len(rs) != len(txs) {
-				continue
-			}
-			for i := range rs {
-				if rs[i].TxHash == hash {
-					if rs[i].BlockNumber != nil && rs[i].BlockHash != (common.Hash{}) {
-						signer := types.LatestSigner(api.b.ChainConfig())
-						return MarshalReceipt(
-							rs[i],
-							rs[i].BlockHash,
-							rs[i].BlockNumber.Uint64(),
-							signer,
-							txs[i],
-							int(rs[i].TransactionIndex),
-						), nil
-					}
-					return api.GetTransactionReceipt(receiptCtx, hash)
-				}
+
+		case ev, open := <-ch:
+			if receipt, done, err := api.receiptFromChainEvent(ctx, ev, open, hash); done {
+				return receipt, err
 			}
 		}
 	}
+}
+
+// txSyncWaitClosed distinguishes the server-side wait window elapsing, which
+// gets the structured timeout naming the pooled transaction, from the caller
+// having given up.
+func txSyncWaitClosed(ctx context.Context, hash common.Hash, timeout time.Duration) error {
+	if !errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		return ctx.Err()
+	}
+
+	return &txSyncTimeoutError{
+		msg:  fmt.Sprintf("The transaction was added to the transaction pool but wasn't processed in %v", timeout),
+		hash: hash,
+	}
+}
+
+// pollReceipt reads the pending view first, which is where a preconfirmation
+// shows up and costs a single in-memory lookup. Only once something is there,
+// or on the backstop tick, is the full lookup worth its two DB point-misses -
+// canonical arrival otherwise reaches awaitReceipt as a chain event. That
+// lookup prefers a canonical receipt and falls back to the same
+// preconfirmation, so there is nothing to return here on its own.
+func (api *TransactionAPI) pollReceipt(ctx context.Context, hash common.Hash, checkCanonical bool) map[string]interface{} {
+	if !checkCanonical && preconfTransactionReceipt(api.b, hash) == nil {
+		return nil
+	}
+
+	return api.receiptIfAvailable(ctx, hash)
+}
+
+func subscriptionFailure(err error, open bool) error {
+	if !open {
+		return errSubClosed
+	}
+
+	return err
+}
+
+// receiptFromChainEvent reports done when ev settles the wait for hash.
+func (api *TransactionAPI) receiptFromChainEvent(
+	ctx context.Context,
+	ev core.ChainEvent,
+	open bool,
+	hash common.Hash,
+) (map[string]interface{}, bool, error) {
+	if !open {
+		return nil, true, errSubClosed
+	}
+
+	rs, txs := ev.Receipts, ev.Transactions
+	if len(rs) == 0 || len(rs) != len(txs) {
+		return nil, false, nil
+	}
+
+	for i := range rs {
+		if rs[i].TxHash != hash {
+			continue
+		}
+
+		if rs[i].BlockNumber != nil && rs[i].BlockHash != (common.Hash{}) {
+			signer := types.LatestSigner(api.b.ChainConfig())
+
+			return MarshalReceipt(
+				rs[i],
+				rs[i].BlockHash,
+				rs[i].BlockNumber.Uint64(),
+				signer,
+				txs[i],
+				int(rs[i].TransactionIndex),
+			), true, nil
+		}
+
+		receipt, err := api.GetTransactionReceipt(ctx, hash)
+
+		return receipt, true, err
+	}
+
+	return nil, false, nil
+}
+
+// enterTxSyncWait admits one more waiter, reporting false once the node holds
+// as many as it is configured for.
+func (api *TransactionAPI) enterTxSyncWait() bool {
+	if api.txSyncWaiters == nil {
+		return true
+	}
+
+	select {
+	case api.txSyncWaiters <- struct{}{}:
+		return true
+	default:
+		return false
+	}
+}
+
+func (api *TransactionAPI) leaveTxSyncWait() {
+	if api.txSyncWaiters == nil {
+		return
+	}
+
+	<-api.txSyncWaiters
 }
 
 func (api *TransactionAPI) preconfReceiptPolling() (<-chan time.Time, func()) {

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -452,6 +452,15 @@ type testBackend struct {
 
 	syncDefaultTimeout time.Duration
 	syncMaxTimeout     time.Duration
+	syncMaxConcurrent  int
+
+	canonicalLookups *atomic.Int64
+
+	// suppressChainEvent keeps an auto-mined tx from publishing a ChainEvent, and
+	// canonicalAfter delays when it becomes readable — together they let a test
+	// make a receipt appear with no event ever naming it.
+	suppressChainEvent bool
+	canonicalAfter     time.Time
 
 	// Relay / preconf / private tx mock controls
 	preconfEnabled   bool
@@ -697,7 +706,7 @@ func (b *testBackend) SendTx(ctx context.Context, tx *types.Transaction) error {
 	b.sentTx = tx
 	b.sentTxHash = tx.Hash()
 
-	if b.autoMine {
+	if b.autoMine && !b.suppressChainEvent {
 		// Synthesize a "mined" receipt at head+1
 		num := b.chain.CurrentHeader().Number.Uint64() + 1
 		receipt := &types.Receipt{
@@ -721,14 +730,22 @@ func (b *testBackend) SendTx(ctx context.Context, tx *types.Transaction) error {
 	return nil
 }
 func (b *testBackend) GetCanonicalTransaction(txHash common.Hash) (bool, *types.Transaction, common.Hash, uint64, uint64) {
+	if b.canonicalLookups != nil {
+		b.canonicalLookups.Add(1)
+	}
+
 	// Treat the auto-mined tx as canonically placed at head+1.
-	if b.autoMine && txHash == b.sentTxHash {
+	if b.autoMine && txHash == b.sentTxHash && b.canonicalReadable() {
 		num := b.chain.CurrentHeader().Number.Uint64() + 1
 		return true, b.sentTx, fakeBlockHash(txHash), num, 0
 	}
 	tx, blockHash, blockNumber, index := rawdb.ReadCanonicalTransaction(b.db, txHash)
 	return tx != nil, tx, blockHash, blockNumber, index
 }
+func (b *testBackend) canonicalReadable() bool {
+	return b.canonicalAfter.IsZero() || !time.Now().Before(b.canonicalAfter)
+}
+
 func (b *testBackend) GetPreconfTransaction(txHash common.Hash) (*types.Transaction, *types.Receipt, bool) {
 	b.preconf.mu.RLock()
 	defer b.preconf.mu.RUnlock()

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -63,6 +63,7 @@ type Backend interface {
 	UnprotectedAllowed() bool      // allows only for EIP155 transactions.
 	RPCTxSyncDefaultTimeout() time.Duration
 	RPCTxSyncMaxTimeout() time.Duration
+	RPCTxSyncMaxConcurrent() int
 
 	// Preconf / Private tx related API for relay
 	PreconfEnabled() bool

--- a/internal/ethapi/bor_api_test.go
+++ b/internal/ethapi/bor_api_test.go
@@ -151,8 +151,13 @@ func (b *testBackend) RPCTxSyncMaxTimeout() time.Duration {
 	return 5 * time.Minute
 }
 
+func (b *testBackend) RPCTxSyncMaxConcurrent() int {
+	return b.syncMaxConcurrent
+}
+
 func (b *backendMock) RPCTxSyncDefaultTimeout() time.Duration { return 2 * time.Second }
 func (b *backendMock) RPCTxSyncMaxTimeout() time.Duration     { return 5 * time.Minute }
+func (b *backendMock) RPCTxSyncMaxConcurrent() int            { return 0 }
 
 func (b *testBackend) Etherbase() (common.Address, error) {
 	return common.Address{}, nil

--- a/internal/ethapi/errors.go
+++ b/internal/ethapi/errors.go
@@ -115,6 +115,7 @@ const (
 	errCodeReverted                = -32000
 	errCodeVMError                 = -32015
 	errCodeTxSyncTimeout           = 4
+	errCodeTxSyncBusy              = -32005
 )
 
 func txValidationError(err error) *invalidTxError {
@@ -175,6 +176,19 @@ type blockGasLimitReachedError struct{ message string }
 
 func (e *blockGasLimitReachedError) Error() string  { return e.message }
 func (e *blockGasLimitReachedError) ErrorCode() int { return errCodeBlockGasLimitReached }
+
+// errTxSyncBusy is returned instead of admitting a waiter the node has no room
+// for. It carries no hash because the transaction was never submitted: the
+// caller can retry, or fall back to eth_sendRawTransaction and poll.
+var errTxSyncBusy = &txSyncBusyError{}
+
+type txSyncBusyError struct{}
+
+func (e *txSyncBusyError) Error() string {
+	return "too many transactions waiting for a synchronous receipt"
+}
+
+func (e *txSyncBusyError) ErrorCode() int { return errCodeTxSyncBusy }
 
 func (e *txSyncTimeoutError) Error() string          { return e.msg }
 func (e *txSyncTimeoutError) ErrorCode() int         { return errCodeTxSyncTimeout }

--- a/internal/ethapi/txsync_wait_test.go
+++ b/internal/ethapi/txsync_wait_test.go
@@ -1,0 +1,582 @@
+package ethapi
+
+import (
+	"context"
+	"errors"
+	"io"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/consensus/ethash"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+func newTxSyncBackend(t *testing.T) *testBackend {
+	t.Helper()
+
+	genesis := &core.Genesis{Config: params.TestChainConfig, Alloc: types.GenesisAlloc{}}
+
+	return newTestBackend(t, 0, genesis, ethash.NewFaker(), nil)
+}
+
+func TestSendRawTransactionSyncWaiterCap(t *testing.T) {
+	t.Parallel()
+
+	b := newTxSyncBackend(t)
+	b.syncMaxConcurrent = 1
+
+	api := NewTransactionAPI(b, new(AddrLocker))
+	raw, _ := makeSelfSignedRaw(t, api, b.acc.Address)
+
+	parked := make(chan struct{})
+
+	go func() {
+		defer close(parked)
+
+		timeout := hexutil.Uint64(800)
+		_, _ = api.SendRawTransactionSync(context.Background(), raw, &timeout)
+	}()
+
+	waitForTxSyncWaiters(t, api, 1)
+
+	timeout := hexutil.Uint64(100)
+
+	receipt, err := api.SendRawTransactionSync(context.Background(), raw, &timeout)
+	if receipt != nil {
+		t.Fatalf("receipt = %#v, want nil", receipt)
+	}
+	if !errors.Is(err, errTxSyncBusy) {
+		t.Fatalf("err = %v, want %v", err, errTxSyncBusy)
+	}
+
+	<-parked
+
+	// The seat is handed back, so the next caller waits rather than being refused.
+	if _, err := api.SendRawTransactionSync(context.Background(), raw, &timeout); errors.Is(err, errTxSyncBusy) {
+		t.Fatal("still refusing callers after the waiter left")
+	}
+}
+
+func TestSendRawTransactionSyncUncapped(t *testing.T) {
+	t.Parallel()
+
+	b := newTxSyncBackend(t)
+	b.syncMaxConcurrent = 0
+
+	api := NewTransactionAPI(b, new(AddrLocker))
+	if api.txSyncWaiters != nil {
+		t.Fatal("waiter admission built for an uncapped node")
+	}
+
+	if !api.enterTxSyncWait() {
+		t.Fatal("uncapped node refused a waiter")
+	}
+
+	api.leaveTxSyncWait()
+}
+
+func TestPollReceipt(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		preconf        bool
+		canonical      bool
+		checkCanonical bool
+		wantReceipt    bool
+		wantPreconf    bool
+	}{
+		{name: "nothing landed"},
+		{name: "preconf only", preconf: true, wantReceipt: true, wantPreconf: true},
+		{name: "preconf prefers canonical", preconf: true, canonical: true, wantReceipt: true},
+		{name: "canonical is not read on a preconf tick", canonical: true},
+		{name: "canonical is read on the backstop tick", canonical: true, checkCanonical: true, wantReceipt: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			b := newTxSyncBackend(t)
+			api := NewTransactionAPI(b, new(AddrLocker))
+			_, tx := makeSelfSignedRaw(t, api, b.acc.Address)
+
+			if tt.canonical {
+				b.autoMine = true
+				b.sentTx, b.sentTxHash = tx, tx.Hash()
+			}
+
+			if tt.preconf {
+				b.preconfEnabled = true
+				b.preconf.tx = tx
+				b.preconf.receipt = &types.Receipt{
+					Type:              tx.Type(),
+					Status:            types.ReceiptStatusSuccessful,
+					CumulativeGasUsed: tx.Gas(),
+					GasUsed:           tx.Gas(),
+					EffectiveGasPrice: tx.GasPrice(),
+					TxHash:            tx.Hash(),
+					BlockNumber:       new(big.Int).Add(b.CurrentBlock().Number, common.Big1),
+				}
+			}
+
+			receipt := api.pollReceipt(context.Background(), tx.Hash(), tt.checkCanonical)
+
+			if (receipt != nil) != tt.wantReceipt {
+				t.Fatalf("receipt = %#v, want receipt: %v", receipt, tt.wantReceipt)
+			}
+			if receipt == nil {
+				return
+			}
+			if got := receipt["preconfirmation"] == true; got != tt.wantPreconf {
+				t.Fatalf("preconfirmation = %v, want %v (receipt %#v)", got, tt.wantPreconf, receipt)
+			}
+		})
+	}
+}
+
+func waitForTxSyncWaiters(t *testing.T, api *TransactionAPI, want int) {
+	t.Helper()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if len(api.txSyncWaiters) == want {
+			return
+		}
+
+		time.Sleep(time.Millisecond)
+	}
+
+	t.Fatalf("waiters = %d, want %d", len(api.txSyncWaiters), want)
+}
+
+func TestTxSyncTimeout(t *testing.T) {
+	t.Parallel()
+
+	ms := func(v uint64) *hexutil.Uint64 {
+		h := hexutil.Uint64(v)
+
+		return &h
+	}
+
+	tests := []struct {
+		name    string
+		request *hexutil.Uint64
+		want    time.Duration
+	}{
+		{name: "unset falls back to default", request: nil, want: 2 * time.Second},
+		{name: "zero falls back to default", request: ms(0), want: 2 * time.Second},
+		{name: "under the ceiling is honoured", request: ms(1500), want: 1500 * time.Millisecond},
+		{name: "at the ceiling", request: ms(300_000), want: 5 * time.Minute},
+		{name: "over the ceiling is clamped", request: ms(600_000), want: 5 * time.Minute},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			api := NewTransactionAPI(newTxSyncBackend(t), new(AddrLocker))
+			if got := api.txSyncTimeout(tt.request); got != tt.want {
+				t.Fatalf("timeout = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTxSyncWaitClosed(t *testing.T) {
+	t.Parallel()
+
+	hash := common.HexToHash("0xabc")
+
+	t.Run("deadline names the pooled transaction", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Nanosecond)
+		defer cancel()
+
+		<-ctx.Done()
+
+		err := txSyncWaitClosed(ctx, hash, 3*time.Second)
+
+		var timeoutErr *txSyncTimeoutError
+		if !errors.As(err, &timeoutErr) {
+			t.Fatalf("err = %T %v, want *txSyncTimeoutError", err, err)
+		}
+		if timeoutErr.ErrorCode() != errCodeTxSyncTimeout {
+			t.Fatalf("code = %d, want %d", timeoutErr.ErrorCode(), errCodeTxSyncTimeout)
+		}
+		if timeoutErr.ErrorData() != hash.Hex() {
+			t.Fatalf("data = %v, want %s", timeoutErr.ErrorData(), hash.Hex())
+		}
+		if !strings.Contains(timeoutErr.Error(), "3s") {
+			t.Fatalf("message %q does not name the wait window", timeoutErr.Error())
+		}
+	})
+
+	t.Run("caller cancellation is passed through", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		if err := txSyncWaitClosed(ctx, hash, time.Second); !errors.Is(err, context.Canceled) {
+			t.Fatalf("err = %v, want %v", err, context.Canceled)
+		}
+	})
+}
+
+func TestSubscriptionFailure(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("feed broke")
+
+	tests := []struct {
+		name string
+		err  error
+		open bool
+		want error
+	}{
+		{name: "closed channel", err: nil, open: false, want: errSubClosed},
+		{name: "live error", err: sentinel, open: true, want: sentinel},
+		{name: "live without error", err: nil, open: true, want: nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := subscriptionFailure(tt.err, tt.open); !errors.Is(got, tt.want) {
+				t.Fatalf("err = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReceiptFromChainEvent(t *testing.T) {
+	t.Parallel()
+
+	b := newTxSyncBackend(t)
+	api := NewTransactionAPI(b, new(AddrLocker))
+	_, tx := makeSelfSignedRaw(t, api, b.acc.Address)
+
+	blockHash := common.HexToHash("0xfeed")
+
+	sealed := &types.Receipt{
+		Type:              tx.Type(),
+		Status:            types.ReceiptStatusSuccessful,
+		CumulativeGasUsed: 21000,
+		GasUsed:           21000,
+		EffectiveGasPrice: big.NewInt(1),
+		TxHash:            tx.Hash(),
+		BlockHash:         blockHash,
+		BlockNumber:       big.NewInt(7),
+		TransactionIndex:  0,
+	}
+	unsealed := &types.Receipt{TxHash: tx.Hash()}
+	other := &types.Receipt{TxHash: common.HexToHash("0xdead"), BlockHash: blockHash, BlockNumber: big.NewInt(7)}
+
+	tests := []struct {
+		name      string
+		open      bool
+		event     core.ChainEvent
+		wantDone  bool
+		wantErr   error
+		wantBlock interface{}
+	}{
+		{
+			name:     "closed feed ends the wait",
+			open:     false,
+			wantDone: true,
+			wantErr:  errSubClosed,
+		},
+		{
+			name:  "empty event keeps waiting",
+			open:  true,
+			event: core.ChainEvent{},
+		},
+		{
+			name:  "mismatched lengths keep waiting",
+			open:  true,
+			event: core.ChainEvent{Receipts: types.Receipts{sealed}, Transactions: types.Transactions{}},
+		},
+		{
+			name:  "other transactions keep waiting",
+			open:  true,
+			event: core.ChainEvent{Receipts: types.Receipts{other}, Transactions: types.Transactions{tx}},
+		},
+		{
+			name:      "sealed receipt is marshalled from the event",
+			open:      true,
+			event:     core.ChainEvent{Receipts: types.Receipts{sealed}, Transactions: types.Transactions{tx}},
+			wantDone:  true,
+			wantBlock: blockHash,
+		},
+		{
+			name:     "receipt without a block falls back to lookup",
+			open:     true,
+			event:    core.ChainEvent{Receipts: types.Receipts{unsealed}, Transactions: types.Transactions{tx}},
+			wantDone: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			receipt, done, err := api.receiptFromChainEvent(context.Background(), tt.event, tt.open, tx.Hash())
+
+			if done != tt.wantDone {
+				t.Fatalf("done = %v, want %v", done, tt.wantDone)
+			}
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("err = %v, want %v", err, tt.wantErr)
+			}
+			if tt.wantBlock == nil {
+				return
+			}
+			if got := receipt["blockHash"]; got != tt.wantBlock {
+				t.Fatalf("blockHash = %v, want %v", got, tt.wantBlock)
+			}
+			if got := receipt["transactionHash"]; got != tx.Hash() {
+				t.Fatalf("transactionHash = %v, want %v", got, tx.Hash())
+			}
+		})
+	}
+}
+
+func TestDecodeRawTransaction(t *testing.T) {
+	t.Parallel()
+
+	b := newTxSyncBackend(t)
+	api := NewTransactionAPI(b, new(AddrLocker))
+	raw, tx := makeSelfSignedRaw(t, api, b.acc.Address)
+
+	t.Run("round trips a signed transaction", func(t *testing.T) {
+		t.Parallel()
+
+		got, err := api.decodeRawTransaction(raw)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.Hash() != tx.Hash() {
+			t.Fatalf("hash = %s, want %s", got.Hash(), tx.Hash())
+		}
+	})
+
+	t.Run("rejects garbage", func(t *testing.T) {
+		t.Parallel()
+
+		if _, err := api.decodeRawTransaction(hexutil.Bytes{0x01, 0x02, 0x03}); err == nil {
+			t.Fatal("expected a decode error")
+		}
+	})
+}
+
+func TestSendRawTransactionSyncBusyDoesNotSubmit(t *testing.T) {
+	t.Parallel()
+
+	b := newTxSyncBackend(t)
+	b.syncMaxConcurrent = 1
+
+	api := NewTransactionAPI(b, new(AddrLocker))
+	raw, _ := makeSelfSignedRaw(t, api, b.acc.Address)
+
+	if !api.enterTxSyncWait() {
+		t.Fatal("could not take the only seat")
+	}
+
+	if _, err := api.SendRawTransactionSync(context.Background(), raw, nil); !errors.Is(err, errTxSyncBusy) {
+		t.Fatalf("err = %v, want %v", err, errTxSyncBusy)
+	}
+	if b.sentTx != nil {
+		t.Fatalf("refused call still submitted %s", b.sentTx.Hash())
+	}
+}
+
+// TestParkedSyncCallDoesNotBlockTheServer drives the real handler over HTTP
+// against a single-slot execution pool. The parked sync call owns that slot
+// when it enters the wait, so a second call can only get through if the wait
+// hands the slot back.
+func TestParkedSyncCallDoesNotBlockTheServer(t *testing.T) {
+	t.Parallel()
+
+	b := newTxSyncBackend(t)
+	b.autoMine = false // nothing ever mines, so the sync call waits out its window
+	b.syncMaxConcurrent = 8
+
+	api := NewTransactionAPI(b, new(AddrLocker))
+	raw, _ := makeSelfSignedRaw(t, api, b.acc.Address)
+
+	server := rpc.NewServer("test", 1, 0)
+	defer server.Stop()
+
+	if err := server.RegisterName("eth", api); err != nil {
+		t.Fatal(err)
+	}
+
+	httpServer := httptest.NewServer(server)
+	defer httpServer.Close()
+
+	post := func(body string, timeout time.Duration) (string, error) {
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		defer cancel()
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, httpServer.URL, strings.NewReader(body))
+		if err != nil {
+			return "", err
+		}
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return "", err
+		}
+		defer resp.Body.Close()
+
+		out, err := io.ReadAll(resp.Body)
+
+		return string(out), err
+	}
+
+	go func() {
+		_, _ = post(`{"jsonrpc":"2.0","id":1,"method":"eth_sendRawTransactionSync","params":["`+raw.String()+`","0x1388"]}`, 30*time.Second)
+	}()
+
+	// A registered waiter means the call is past admission and holding the
+	// pool's only slot.
+	waitForTxSyncWaiters(t, api, 1)
+
+	got, err := post(`{"jsonrpc":"2.0","id":2,"method":"eth_getTransactionCount","params":["`+b.acc.Address.Hex()+`","pending"]}`, 2*time.Second)
+	if err != nil {
+		t.Fatalf("second call blocked behind the parked sync call: %v", err)
+	}
+	if !strings.Contains(got, `"result"`) {
+		t.Fatalf("unexpected response: %s", got)
+	}
+}
+
+func TestSendRawTransactionRejectsGarbage(t *testing.T) {
+	t.Parallel()
+
+	b := newTxSyncBackend(t)
+	api := NewTransactionAPI(b, new(AddrLocker))
+	garbage := hexutil.Bytes{0x01, 0x02, 0x03}
+
+	t.Run("async", func(t *testing.T) {
+		t.Parallel()
+
+		if _, err := api.SendRawTransaction(context.Background(), garbage); err == nil {
+			t.Fatal("expected a decode error")
+		}
+	})
+
+	t.Run("sync", func(t *testing.T) {
+		t.Parallel()
+
+		if _, err := api.SendRawTransactionSync(context.Background(), garbage, nil); err == nil {
+			t.Fatal("expected a decode error")
+		}
+	})
+
+	if b.sentTx != nil {
+		t.Fatalf("undecodable input reached the pool as %s", b.sentTx.Hash())
+	}
+}
+
+// TestPreconfTickSkipsCanonicalLookup pins the point of reading only the
+// pending view on a preconf tick: the on-disk lookup costs two point-misses
+// per waiter per tick, and canonical arrival comes in as a chain event.
+func TestPreconfTickSkipsCanonicalLookup(t *testing.T) {
+	t.Parallel()
+
+	b := newTxSyncBackend(t)
+	b.canonicalLookups = new(atomic.Int64)
+
+	api := NewTransactionAPI(b, new(AddrLocker))
+	_, tx := makeSelfSignedRaw(t, api, b.acc.Address)
+
+	if got := api.pollReceipt(context.Background(), tx.Hash(), false); got != nil {
+		t.Fatalf("receipt = %#v, want nil", got)
+	}
+	if got := b.canonicalLookups.Load(); got != 0 {
+		t.Fatalf("preconf tick made %d canonical lookups, want 0", got)
+	}
+
+	if got := api.pollReceipt(context.Background(), tx.Hash(), true); got != nil {
+		t.Fatalf("receipt = %#v, want nil", got)
+	}
+	if got := b.canonicalLookups.Load(); got == 0 {
+		t.Fatal("backstop tick made no canonical lookup")
+	}
+}
+
+// TestBackstopFindsReceiptWithoutChainEvent covers the gap the backstop exists
+// for: the transaction goes canonical but no chain event names it, so the only
+// way out of the wait is the periodic on-disk lookup.
+func TestBackstopFindsReceiptWithoutChainEvent(t *testing.T) {
+	t.Parallel()
+
+	b := newTxSyncBackend(t)
+
+	api := NewTransactionAPI(b, new(AddrLocker))
+	raw, tx := makeSelfSignedRaw(t, api, b.acc.Address)
+
+	b.autoMine = true
+	b.suppressChainEvent = true
+	b.sentTx, b.sentTxHash = tx, tx.Hash()
+	// Not readable on the fast path, so only a later backstop tick can find it.
+	b.canonicalAfter = time.Now().Add(200 * time.Millisecond)
+
+	timeout := hexutil.Uint64(10_000)
+
+	start := time.Now()
+
+	receipt, err := api.SendRawTransactionSync(context.Background(), raw, &timeout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if receipt == nil || receipt["transactionHash"] != tx.Hash() {
+		t.Fatalf("receipt = %#v", receipt)
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Fatalf("backstop took %v, want it inside a few ticks", elapsed)
+	}
+}
+
+// TestWaitLoopPollsPendingViewOnly checks the tick wiring, not just pollReceipt
+// in isolation: across a whole wait window the loop must not be issuing an
+// on-disk lookup per 100ms tick.
+func TestWaitLoopPollsPendingViewOnly(t *testing.T) {
+	t.Parallel()
+
+	b := newTxSyncBackend(t)
+	b.autoMine = false
+	b.preconfEnabled = true // switches the 100ms preconf tick on
+	b.canonicalLookups = new(atomic.Int64)
+
+	api := NewTransactionAPI(b, new(AddrLocker))
+	raw, _ := makeSelfSignedRaw(t, api, b.acc.Address)
+
+	// Shorter than the 1s canonical backstop, so every lookup beyond the fast
+	// path would have to come from a preconf tick.
+	timeout := hexutil.Uint64(700)
+
+	if _, err := api.SendRawTransactionSync(context.Background(), raw, &timeout); err == nil {
+		t.Fatal("expected the wait window to elapse")
+	}
+
+	// One for the fast path, and no backstop tick inside 700ms.
+	if got := b.canonicalLookups.Load(); got > 3 {
+		t.Fatalf("%d canonical lookups over a 700ms wait, want the ticks to stay off disk", got)
+	}
+}

--- a/rpc/execution_pool.go
+++ b/rpc/execution_pool.go
@@ -61,13 +61,29 @@ func NewExecutionPool(initialSize int, timeout time.Duration, service string, re
 // slot, falling back to an unbounded run if ctx is cancelled or the configured
 // timeout elapses, so a saturated pool can't block the caller indefinitely.
 func (s *SafePool) Submit(ctx context.Context, fn func() error) (<-chan error, bool) {
+	s.SubmitWithSlot(ctx, func(*Slot) error {
+		return fn()
+	})
+
+	return nil, true
+}
+
+// SubmitWithSlot is Submit for tasks that manage their own hold on the pool: fn
+// receives the slot acquired for it and may hand it back for the duration of a
+// wait that isn't work of its own. The slot is nil when the task runs unbounded
+// (fast path, or the saturation fallback), and a nil slot's methods are no-ops.
+func (s *SafePool) SubmitWithSlot(ctx context.Context, fn func(*Slot) error) {
+	unbounded := func() {
+		go func() {
+			_ = fn(nil)
+		}()
+	}
+
 	semPtr := s.sem.Load()
 	if s.fastPath.Load() || semPtr == nil {
-		go func() {
-			_ = fn()
-		}()
+		unbounded()
 
-		return nil, true
+		return
 	}
 
 	sem := *semPtr
@@ -83,25 +99,18 @@ func (s *SafePool) Submit(ctx context.Context, fn func() error) (<-chan error, b
 	case sem <- struct{}{}: // acquired a slot
 		s.inFlight.Add(1)
 
-		go func() {
-			defer func() {
-				<-sem
-				s.inFlight.Add(-1)
-			}()
+		slot := &Slot{pool: s, sem: sem, held: true}
 
-			_ = fn()
+		go func() {
+			defer slot.Release()
+
+			_ = fn(slot)
 		}()
 	case <-ctx.Done():
-		go func() {
-			_ = fn()
-		}()
+		unbounded()
 	case <-timeout:
-		go func() {
-			_ = fn()
-		}()
+		unbounded()
 	}
-
-	return nil, true
 }
 
 func (s *SafePool) ChangeSize(n int) {

--- a/rpc/execution_slot.go
+++ b/rpc/execution_slot.go
@@ -1,0 +1,70 @@
+package rpc
+
+import "context"
+
+// Slot is a task's hold on an execution pool. A handler that blocks on an
+// external event rather than on work of its own can hand the slot back for the
+// duration of the wait: a parked goroutine costs a few kilobytes, while a slot
+// is a fraction of the node's entire RPC concurrency budget.
+//
+// A slot belongs to the single goroutine SubmitWithSlot handed it to. Release
+// and Acquire are idempotent but not safe to call concurrently with each other.
+type Slot struct {
+	pool *SafePool
+	sem  chan struct{} // the semaphore this hold came from; ChangeSize may since have swapped it
+	held bool
+}
+
+// Release hands the slot back to the pool.
+func (s *Slot) Release() {
+	if s == nil || !s.held {
+		return
+	}
+
+	s.held = false
+	<-s.sem
+	s.pool.inFlight.Add(-1)
+}
+
+// Acquire takes a slot back, from the pool's current semaphore so a task that
+// waited through a ChangeSize rejoins under the new bound. It is best effort: a
+// saturated pool lets the caller proceed rather than parking it, because
+// callers that release a slot are bounded by their own admission limit, and
+// blocking here would stop them draining the events they were waiting on.
+func (s *Slot) Acquire() {
+	if s == nil || s.held {
+		return
+	}
+
+	semPtr := s.pool.sem.Load()
+	if s.pool.fastPath.Load() || semPtr == nil {
+		return // the pool went unbounded while we were waiting
+	}
+
+	sem := *semPtr
+
+	select {
+	case sem <- struct{}{}:
+		s.sem = sem
+		s.held = true
+		s.pool.inFlight.Add(1)
+	default:
+	}
+}
+
+type slotKey struct{}
+
+// withExecutionSlot publishes the task's hold for its handler. A nil slot is
+// stored as-is: it reads back as a nil *Slot, whose methods are no-ops.
+func withExecutionSlot(ctx context.Context, slot *Slot) context.Context {
+	return context.WithValue(ctx, slotKey{}, slot)
+}
+
+// ExecutionSlotFromContext returns the calling handler's hold on the execution
+// pool, or nil when the call isn't running under a bounded one. Callers don't
+// need the nil check — a nil slot's methods are no-ops.
+func ExecutionSlotFromContext(ctx context.Context) *Slot {
+	slot, _ := ctx.Value(slotKey{}).(*Slot)
+
+	return slot
+}

--- a/rpc/execution_slot_test.go
+++ b/rpc/execution_slot_test.go
@@ -1,0 +1,435 @@
+package rpc
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSlotReleaseFreesCapacity(t *testing.T) {
+	t.Parallel()
+
+	pool := NewExecutionPool(1, 0, "test", false)
+
+	released := make(chan struct{})
+	unblock := make(chan struct{})
+
+	pool.SubmitWithSlot(context.Background(), func(slot *Slot) error {
+		slot.Release()
+		close(released)
+		<-unblock
+
+		return nil
+	})
+	<-released
+	defer close(unblock)
+
+	ran := make(chan struct{})
+	pool.Submit(context.Background(), func() error {
+		close(ran)
+
+		return nil
+	})
+
+	select {
+	case <-ran:
+	case <-time.After(2 * time.Second):
+		t.Fatal("second task never got a slot while the first was parked")
+	}
+}
+
+func TestSlotReleaseIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	pool := NewExecutionPool(1, 0, "test", false)
+
+	done := make(chan struct{})
+	pool.SubmitWithSlot(context.Background(), func(slot *Slot) error {
+		slot.Release()
+		slot.Release()
+		close(done)
+
+		return nil
+	})
+	<-done
+
+	// A second release would have drained a slot nobody held, letting the pool
+	// admit two tasks at size 1.
+	if got := pool.inFlight.Load(); got != 0 {
+		t.Fatalf("inFlight = %d, want 0", got)
+	}
+
+	sem := *pool.sem.Load()
+	if got := len(sem); got != 0 {
+		t.Fatalf("semaphore holds %d slots, want 0", got)
+	}
+}
+
+func TestSlotAcquireIsBestEffort(t *testing.T) {
+	t.Parallel()
+
+	pool := NewExecutionPool(1, 0, "test", false)
+
+	held := make(chan bool, 1)
+	pool.SubmitWithSlot(context.Background(), func(slot *Slot) error {
+		slot.Release()
+
+		// Saturate the pool behind the slot's back, so reacquiring can only
+		// succeed by blocking — which it must not do.
+		sem := *pool.sem.Load()
+		sem <- struct{}{}
+
+		defer func() { <-sem }()
+
+		slot.Acquire()
+		held <- slot.held
+
+		return nil
+	})
+
+	select {
+	case got := <-held:
+		if got {
+			t.Fatal("Acquire reported a hold it never got")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Acquire blocked on a saturated pool")
+	}
+}
+
+func TestSlotAcquireAfterChangeSize(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		newSize  int
+		wantHeld bool
+	}{
+		{name: "resized", newSize: 4, wantHeld: true},
+		{name: "unbounded", newSize: 0, wantHeld: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			pool := NewExecutionPool(1, 0, "test", false)
+
+			held := make(chan bool, 1)
+			pool.SubmitWithSlot(context.Background(), func(slot *Slot) error {
+				slot.Release()
+				pool.ChangeSize(tt.newSize)
+				slot.Acquire()
+				held <- slot.held
+
+				return nil
+			})
+
+			if got := <-held; got != tt.wantHeld {
+				t.Fatalf("held = %v, want %v", got, tt.wantHeld)
+			}
+		})
+	}
+}
+
+func TestSubmitWithSlotUnboundedPoolHasNoSlot(t *testing.T) {
+	t.Parallel()
+
+	pool := NewExecutionPool(0, 0, "test", false)
+
+	slots := make(chan *Slot, 1)
+	pool.SubmitWithSlot(context.Background(), func(slot *Slot) error {
+		slots <- slot
+
+		return nil
+	})
+
+	if slot := <-slots; slot != nil {
+		t.Fatalf("slot = %v, want nil on the unbounded fast path", slot)
+	}
+}
+
+// TestLongCallDoesNotStarveTransport is the regression this whole mechanism
+// exists for: a handler that parks waiting on something other than work must
+// not hold the transport's only execution slot while it does.
+//
+// It has to go over HTTP. DialInProc serves the connection through a client
+// handler with its own 100-slot pool, so an in-process call never touches the
+// server's execution pool at all.
+func TestLongCallDoesNotStarveTransport(t *testing.T) {
+	t.Parallel()
+
+	svc, url, stop := newParkingServer(t, false)
+	defer stop()
+
+	parkDone := park(t, url, svc)
+	defer parkDone()
+
+	if err := callQuick(url, 2*time.Second); err != nil {
+		t.Fatalf("quick call blocked behind the parked one: %v", err)
+	}
+}
+
+// TestHeldSlotStarvesTransport pins the other side of the same behaviour: a
+// handler that keeps its slot while parked does block the transport, which is
+// what SendRawTransactionSync used to do.
+func TestHeldSlotStarvesTransport(t *testing.T) {
+	t.Parallel()
+
+	svc, url, stop := newParkingServer(t, true)
+	defer stop()
+
+	parkDone := park(t, url, svc)
+	defer parkDone()
+
+	if err := callQuick(url, 500*time.Millisecond); err == nil {
+		t.Fatal("quick call succeeded while the only slot was held")
+	}
+}
+
+func newParkingServer(t *testing.T, keepSlot bool) (*parkingService, string, func()) {
+	t.Helper()
+
+	server := NewServer("test", 1, 0)
+
+	svc := &parkingService{
+		parked:  make(chan struct{}),
+		unblock: make(chan struct{}),
+		keep:    keepSlot,
+	}
+	if err := server.RegisterName("test", svc); err != nil {
+		t.Fatal(err)
+	}
+
+	httpServer := httptest.NewServer(server)
+
+	return svc, httpServer.URL, func() {
+		httpServer.Close()
+		server.Stop()
+	}
+}
+
+// park starts a call that occupies the handler and waits until it is in the
+// park, returning a function that lets it finish.
+func park(t *testing.T, url string, svc *parkingService) func() {
+	t.Helper()
+
+	go func() {
+		_, _ = http.Post(url, "application/json",
+			strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"test_park","params":[]}`))
+	}()
+
+	select {
+	case <-svc.parked:
+	case <-time.After(5 * time.Second):
+		t.Fatal("park handler never ran")
+	}
+
+	return func() { close(svc.unblock) }
+}
+
+func callQuick(url string, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url,
+		strings.NewReader(`{"jsonrpc":"2.0","id":2,"method":"test_quick","params":[]}`))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	if !strings.Contains(string(body), `"quick"`) {
+		return fmt.Errorf("unexpected response %q", body)
+	}
+
+	return nil
+}
+
+type parkingService struct {
+	parked  chan struct{}
+	unblock chan struct{}
+	keep    bool // hold the slot across the park instead of releasing it
+}
+
+func (s *parkingService) Park(ctx context.Context) (string, error) {
+	if !s.keep {
+		slot := ExecutionSlotFromContext(ctx)
+		slot.Release()
+
+		defer slot.Acquire()
+	}
+
+	close(s.parked)
+	<-s.unblock
+
+	return "parked", nil
+}
+
+func (s *parkingService) Quick() (string, error) {
+	return "quick", nil
+}
+
+// TestSubmitFallsBackWhenSaturated covers the two escape hatches that keep a
+// full pool from blocking a submitter forever: an elapsed pool timeout, and a
+// cancelled caller context. In both cases fn still has to run, because the
+// caller's WaitGroup is counting on it.
+func TestSubmitFallsBackWhenSaturated(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		timeout time.Duration
+		ctx     func() (context.Context, context.CancelFunc)
+	}{
+		{
+			name:    "pool timeout elapses",
+			timeout: 10 * time.Millisecond,
+			ctx: func() (context.Context, context.CancelFunc) {
+				return context.Background(), func() {}
+			},
+		},
+		{
+			name:    "caller gives up",
+			timeout: 0,
+			ctx: func() (context.Context, context.CancelFunc) {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+
+				return ctx, func() {}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			pool := NewExecutionPool(1, tt.timeout, "test", false)
+
+			// Take the only slot and keep it.
+			sem := *pool.sem.Load()
+			sem <- struct{}{}
+
+			defer func() { <-sem }()
+
+			ctx, cancel := tt.ctx()
+			defer cancel()
+
+			ran := make(chan struct{})
+			pool.Submit(ctx, func() error {
+				close(ran)
+
+				return nil
+			})
+
+			select {
+			case <-ran:
+			case <-time.After(2 * time.Second):
+				t.Fatal("fn never ran on a saturated pool")
+			}
+		})
+	}
+}
+
+func TestNilSlotMethodsAreNoOps(t *testing.T) {
+	t.Parallel()
+
+	var slot *Slot
+
+	// A handler on the unbounded fast path gets no slot and must not have to
+	// check for one.
+	slot.Release()
+	slot.Acquire()
+}
+
+func TestAcquireWhileHeldTakesNothing(t *testing.T) {
+	t.Parallel()
+
+	pool := NewExecutionPool(2, 0, "test", false)
+
+	type state struct {
+		held     bool
+		semLen   int
+		inFlight int64
+	}
+
+	got := make(chan state, 1)
+	pool.SubmitWithSlot(context.Background(), func(slot *Slot) error {
+		// Already holding one; acquiring again must not take a second.
+		slot.Acquire()
+
+		got <- state{
+			held:     slot.held,
+			semLen:   len(*pool.sem.Load()),
+			inFlight: pool.inFlight.Load(),
+		}
+
+		return nil
+	})
+
+	s := <-got
+	if !s.held {
+		t.Fatal("slot stopped reporting a hold it still has")
+	}
+	if s.semLen != 1 {
+		t.Fatalf("semaphore holds %d slots, want 1", s.semLen)
+	}
+	if s.inFlight != 1 {
+		t.Fatalf("inFlight = %d, want 1", s.inFlight)
+	}
+}
+
+func TestReacquireRestoresInFlight(t *testing.T) {
+	t.Parallel()
+
+	pool := NewExecutionPool(2, 0, "test", false)
+
+	type sample struct{ released, reacquired int64 }
+
+	got := make(chan sample, 1)
+	pool.SubmitWithSlot(context.Background(), func(slot *Slot) error {
+		slot.Release()
+		released := pool.inFlight.Load()
+
+		slot.Acquire()
+		got <- sample{released: released, reacquired: pool.inFlight.Load()}
+
+		return nil
+	})
+
+	s := <-got
+	if s.released != 0 {
+		t.Fatalf("inFlight = %d while released, want 0", s.released)
+	}
+	if s.reacquired != 1 {
+		t.Fatalf("inFlight = %d after reacquiring, want 1", s.reacquired)
+	}
+}
+
+func TestFastPathHandlerSeesNoSlotOnContext(t *testing.T) {
+	t.Parallel()
+
+	if slot := ExecutionSlotFromContext(context.Background()); slot != nil {
+		t.Fatalf("slot = %v, want nil when no pool published one", slot)
+	}
+
+	if got := withExecutionSlot(context.Background(), nil); ExecutionSlotFromContext(got) != nil {
+		t.Fatal("a nil slot was published on the context")
+	}
+}

--- a/rpc/handler.go
+++ b/rpc/handler.go
@@ -416,11 +416,11 @@ func (h *handler) startCallProc(fn func(*callProc)) {
 
 	ctx, cancel := context.WithCancel(h.rootCtx)
 
-	h.executionPool.Submit(context.Background(), func() error {
+	h.executionPool.SubmitWithSlot(context.Background(), func(slot *Slot) error {
 		defer h.callWG.Done()
 		defer cancel()
 
-		fn(&callProc{ctx: ctx})
+		fn(&callProc{ctx: withExecutionSlot(ctx, slot)})
 
 		h.executionPool.processed.Add(1)
 


### PR DESCRIPTION
## Summary

`eth_sendRawTransactionSync` did real work for microseconds — decode, submit to the txpool, submit for preconf — then held its `rpc.SafePool` execution slot while **idling** in the receipt wait for up to `rpc.txsync.defaulttimeout` (20s). Because bor bounds every RPC call to `ep-size` (40 per transport, with `ep-requesttimeout` at `0` disabling the unbounded fallback), that capped concurrent sync calls at the pool size and let a handful of long-held calls monopolise a transport for a full wait window.

The wait now runs without a slot:

- **`rpc.Slot`** — a releasable hold on the pool, handed to a task by `SafePool.SubmitWithSlot` and published on the call context. `awaitReceipt` releases it on entry and reacquires on exit, so decode/submit and the response tail stay bounded and only the idling is exempt. Reacquisition is best effort — parking there would stop the caller draining the channels it's waiting on.
- **`rpc.txsync.maxconcurrent`** (default 4096) bounds waiters instead, checked *before* submission so a refusal (`-32005`) means the transaction was never accepted and the caller can retry or fall back to `eth_sendRawTransaction`. This also caps live chain-event subscriptions.
- **Cheaper waiting** — the 100ms tick called the full `GetTransactionReceipt`, two DB point-misses before reaching the preconf index. Canonical arrival already comes in as a chain event, so the tick now reads only the in-memory pending view, with a 1s canonical backstop for an event that carried no matching receipts. That backstop also closes a gap: with preconfs off there was previously no poll at all, so a missed or receipt-less event meant waiting out the whole timeout.
- The blob-sidecar upgrade duplicated in `SendRawTransaction` / `SendRawTransactionSync` is factored into `decodeRawTransaction`; behaviour unchanged.

### Measured

One Kurtosis devnet, **two RPC nodes differing only in this change** (same chain, 1s blocks, default `ep-size` 40), 200 concurrent `eth_sendRawTransactionSync` from one funded account, plus a 50ms `eth_chainId` canary on the same transport to measure starvation directly:

| | baseline | fixed |
| --- | --- | --- |
| responses returned (no seqstore) | 30/200 | **200/200** |
| wall clock for 200 | 96.9 s | **0.79 s** |
| max txs in one block | 16 | **200** |
| canary worst latency | 95.8 s | **7 ms** |
| responses returned (seqstore on) | 8/200 | **200/200** |
| wall clock for 200 | 120.0 s | **0.46 s** |
| max txs in one block | 6 | **200** |
| canary worst latency | 119.7 s | **4 ms** |

Reproduced in both orders (fixed 200/200 in 0.45s; baseline 4/200 in 120.4s). **Control at n=30, below `ep-size`:** both nodes 30/30 with a healthy canary — this removes a ceiling, it doesn't make the node generally faster.

On the baseline the failures are 155 dropped connections plus 15 `-32002 request timed out`: bor's HTTP server times out and closes the socket while the call is still queued for a slot. The transactions still land (the nonce advanced by all 200), so the caller loses the **response**, not the transaction — a nastier failure mode than a clean error, and probably why `--sync-txs` looked erratic rather than merely slow under load.

**Preconfirmations are unaffected** — identical on both builds with the sequence store live: 20/20 responses, 16/20 preconfirmed, ~200ms p50 on each.

## Executed tests

Beyond CI's unit/integration gates:

- The devnet A/B above (`kurtosis-pos` @ `seq-store-testing`, anvil L1), four runs in both orders plus the n=30 control, repeated with `el_bor_use_sequence_store` on and the full store stack up.
- `TestParkedSyncCallDoesNotBlockTheServer` drives the real handler over HTTP against a one-slot pool; confirmed to fail on a full-package run when `slot.Release()` is removed, so it's a real regression test. `TestLongCallDoesNotStarveTransport` / `TestHeldSlotStarvesTransport` pin both directions at the `rpc` layer.
- `-race` clean on `rpc` and `internal/ethapi`; green on `internal/cli/...`, `cmd/utils`, `eth/ethconfig`, `eth/filters`.
- diffguard: no new complexity / size / dependency-cycle violations. Mutation 84.6% (T1 logic 87.5%); every survivor in this change's own code was re-checked by hand. Two were genuine gaps, now covered (`Acquire` on a nil slot, and on an already-held slot — the latter would have taken a second semaphore slot and leaked it). Two were dead code found this way and deleted rather than tested around: the `if slot == nil` guard in `withExecutionSlot`, and the `return preconf` branch in `pollReceipt` (unreachable, since `receiptIfAvailable` already falls back to the same preconfirmation). Remaining survivors are the pre-existing blob-sidecar path and generated mock / config plumbing.
- `docs/cli/{server.md,default_config.toml}` regenerated with `make docs`.

⚠️ **Note for anyone writing similar tests:** `DialInProc` does **not** exercise the server's execution pool. It submits `ServeCodec` as one long-lived pool task, and per-call handling goes through `initClient`, which builds its own 100-slot pool — so an in-process test of `ep-size` or starvation passes whether or not the fix is present. My first version of this test did exactly that. Pool behaviour has to be tested over HTTP.

## Rollout notes

Not consensus-affecting; no coordinated upgrade. RPC-only, and the behaviour change is confined to `eth_sendRawTransactionSync`, which hasn't shipped.

One new operator-facing knob: `rpc.txsync.maxconcurrent` (default 4096, `0` disables). Over the cap, callers get `-32005 "too many transactions waiting for a synchronous receipt"` and the transaction is not submitted.

**Follow-up, not in this PR:** each waiter holds its own `SubscribeChainEvent` subscription, and `event.Feed.Send` blocks until every subscriber accepts. Invisible at 40 concurrent waiters; at thousands it's a fan-out on the block-import path. The fix is a single node-wide waiter registry keyed by tx hash (one subscription, one tick) instead of one per call.

### Relationship to the preconfirmation-coverage work

To be explicit, since these are easy to conflate: this PR does **not** touch preconfirmation coverage, and none of the numbers above are coverage numbers. Coverage at high `tx/block` (the 72% → 25% → 6% collapse, and the `ClaimPreconfPrefix` import-vs-serial-session race) lives in `eth/sequencer` and `core/blockchain.go`; this change is confined to `rpc/`, `internal/ethapi/` and config plumbing, and touches neither the publish path, the pending store, nor the consumer session.

Coverage measured identical on both builds where I did measure it (20/20 responses, 16/20 preconfirmed on each) — but that was ~20 tx/block, far below the regime where coverage actually degrades, so treat it only as evidence this change is coverage-neutral, not as a coverage datapoint.

One consequence worth knowing for that work: the `ep-size` ceiling meant load driven through `eth_sendRawTransactionSync` could not exceed ~40-56 tx/block, so it could never reach the 2000-4000 tx/block regime at all. With the ceiling gone (200 tx in a single block above), the sync API can now generate that load — which should make the coverage curve reproducible through this path, though it will expose the collapse rather than improve it.
