### PR TITLE
eth: avoid race in relay-fetch test setup

### DIFF
--- a/eth/handler_wit_relay_fetch_test.go
+++ b/eth/handler_wit_relay_fetch_test.go
@@ -896,8 +896,8 @@ func TestTriggerRelayFetch_DroppedByCapCanBeRetriedOnceCapacityFrees(t *testing.
 	hash := common.HexToHash("0xd00d")
 	healthy := &fakeWitnessPeer{pages: map[uint64][]byte{0: goodData}, totalPages: 1}
 	healthyPeer := newFakeEthPeerWithWitness(211, healthy)
-	registerFakePeer(h.peers, healthyPeer)
 	healthyPeer.witPeer.Peer.AddKnownWitness(hash)
+	registerFakePeer(h.peers, healthyPeer)
 
 	dropsBefore := wit2RelayFetchConcurrencyDropMeter.Snapshot().Count()
 	h.triggerRelayFetch(hash, wantHash, "")


### PR DESCRIPTION
## Summary

Fixes the test-only data race reported by [nightly race run 34008680791](https://github.com/0xPolygon/bor/actions/runs/34008680791) after WIT2 landed in #2208.

The relay-fetch concurrency-cap test registered a `fakeWitnessPeer` and then marked its witness as known. Existing filler fetch goroutines could discover the registered fake in `peersWithWitnessCandidates` while `AddKnownWitness` was still mutating the fake's raw map. Production peers use the thread-safe `wit.KnownCache`, so this was a fixture-publication bug rather than a Bor runtime race.

The fix fully initializes the fake before registering it in the shared peer set. No production behavior changes.

## Executed tests

- Reproduced the original race on current `develop` with the CI shuffle seed before the fix.
- `go test -race ./eth -run '^TestTriggerRelayFetch_DroppedByCapCanBeRetriedOnceCapacityFrees$' -shuffle=1788666289930045044 -count=100`
- Repeated every test added by #2208 under `-race` with randomized order, 20 times; no additional races found.
- `go test -race ./consensus/bor ./core/stateless ./eth ./eth/fetcher ./eth/protocols/wit`
- `go test -race ./consensus/bor ./core/stateless ./eth ./eth/fetcher ./eth/protocols/wit -shuffle=on -count=1`
- `go vet ./eth`
- `make lint` (`0 issues`)
- Diffguard with 100% mutation sampling; no production Go regions were eligible because the diff is test-only.

## Rollout notes

Test-only change. No consensus, networking, configuration, or operator impact. The full repository-wide nightly race workflow remains the final CI-level validation.
