### PR TITLE
eth, eth/sequencer: serve head-state pending in the preconf import gap

### DIFF
--- a/eth/api_backend_pending.go
+++ b/eth/api_backend_pending.go
@@ -26,20 +26,39 @@ func (b *EthAPIBackend) PendingBlock() *types.Block {
 	if block := b.sequencerPendingBlock(); block != nil {
 		return block
 	}
-	if b.eth.miner == nil {
-		return nil
+	if b.eth.miner != nil {
+		if block := b.eth.miner.PendingBlock(); block != nil {
+			return block
+		}
 	}
-	return b.eth.miner.PendingBlock()
+	// Keep the "pending" block accessors consistent with the pending state
+	// below during the import->next-open gap.
+	block, _ := b.headPendingBlock()
+	return block
 }
 
 func (b *EthAPIBackend) PendingBlockAndReceipts() (*types.Block, types.Receipts) {
 	if block, receipts := b.sequencerPendingBlockAndReceipts(); block != nil {
 		return block, receipts
 	}
-	if b.eth.miner == nil {
+	if b.eth.miner != nil {
+		if block, receipts, _ := b.eth.miner.Pending(); block != nil {
+			return block, receipts
+		}
+	}
+	return b.headPendingBlock()
+}
+
+// headPendingBlock is the block half of the head fallback, shared by the
+// pending block accessors.
+func (b *EthAPIBackend) headPendingBlock() (*types.Block, types.Receipts) {
+	if b.eth.seqConsumer == nil {
 		return nil, nil
 	}
-	block, receipts, _ := b.eth.miner.Pending()
+	block, receipts, statedb, err := b.eth.seqConsumer.HeadPendingView()
+	if err != nil || block == nil || statedb == nil {
+		return nil, nil
+	}
 	return block, receipts
 }
 
@@ -76,6 +95,15 @@ func (b *EthAPIBackend) PendingSnapshot(ctx context.Context) (*types.Block, type
 	if b.eth.miner != nil {
 		block, receipts, statedb := b.eth.miner.Pending()
 		if block != nil && statedb != nil {
+			return block, receipts, statedb, nil
+		}
+	}
+	// Last resort for a non-mining sequencer RPC node in the import->next-open
+	// gap: an empty head block keeps pending state available instead of
+	// erroring for ~150ms every block.
+	if b.eth.seqConsumer != nil {
+		block, receipts, statedb, err := b.eth.seqConsumer.HeadPendingView()
+		if err == nil && block != nil && statedb != nil {
 			return block, receipts, statedb, nil
 		}
 	}

--- a/eth/api_backend_sequencer_test.go
+++ b/eth/api_backend_sequencer_test.go
@@ -31,6 +31,13 @@ type apiSequenceConsumer struct {
 	rangeBlocks   []*types.Block
 	rangeReceipts []types.Receipts
 	snapshotErr   error
+	headBlock     *types.Block
+	headState     *state.StateDB
+	headErr       error
+}
+
+func (c *apiSequenceConsumer) HeadPendingView() (*types.Block, types.Receipts, *state.StateDB, error) {
+	return c.headBlock, nil, c.headState, c.headErr
 }
 
 func (c *apiSequenceConsumer) PendingSnapshot(context.Context) (*types.Block, types.Receipts, *state.StateDB, error) {
@@ -270,5 +277,46 @@ func TestSequencerPendingSnapshotFailures(t *testing.T) {
 	b.eth.seqConsumer = &apiSequenceConsumer{index: sequencer.NewIndex()}
 	if _, _, _, err := b.PendingSnapshot(t.Context()); err == nil {
 		t.Fatal("empty snapshot did not fail")
+	}
+}
+
+// A non-mining RPC node with the sequencer enabled has no miner pending, and
+// between importing a block and receiving the next open the consumer has no
+// active entry. The backend must then serve the consumer's head fallback so
+// pending state stays available instead of returning -32000; without it,
+// go-ethereum bind's default eth_getCode(addr,"pending") gas preflight fails
+// for ~150ms every block.
+func TestSequencerPendingSnapshotHeadFallback(t *testing.T) {
+	b := initBackend(false)
+	defer b.eth.blockchain.Stop()
+	defer b.eth.txPool.Close()
+
+	head := b.eth.blockchain.CurrentBlock()
+	statedb, err := b.eth.blockchain.StateAt(head.Root)
+	if err != nil {
+		t.Fatalf("state: %v", err)
+	}
+	empty := types.NewBlockWithHeader(&types.Header{
+		ParentHash: head.Hash(),
+		Number:     new(big.Int).Add(head.Number, big.NewInt(1)),
+	})
+
+	// No live entry (PendingSnapshot nil), no miner, but a head view is offered.
+	b.eth.seqConsumer = &apiSequenceConsumer{index: sequencer.NewIndex(), headBlock: empty, headState: statedb}
+
+	block, _, gotState, err := b.PendingSnapshot(t.Context())
+	if err != nil {
+		t.Fatalf("head fallback should serve pending, got error: %v", err)
+	}
+	if block != empty || gotState != statedb {
+		t.Fatal("backend did not fall back to the consumer head view")
+	}
+	// The block accessors must serve the same head view, so
+	// eth_getBlockByNumber("pending") does not return null in the gap.
+	if pb := b.PendingBlock(); pb != empty {
+		t.Fatalf("PendingBlock did not use the head fallback: %v", pb)
+	}
+	if pb, _ := b.PendingBlockAndReceipts(); pb != empty {
+		t.Fatalf("PendingBlockAndReceipts did not use the head fallback: %v", pb)
 	}
 }

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -78,6 +78,7 @@ import (
 
 type sequenceConsumer interface {
 	PendingSnapshot(context.Context) (*types.Block, types.Receipts, *state.StateDB, error)
+	HeadPendingView() (*types.Block, types.Receipts, *state.StateDB, error)
 	PendingBlock() *types.Block
 	PendingBlockAndReceipts() (*types.Block, types.Receipts)
 	PendingLogRange() (*types.Header, []*types.Block, []types.Receipts)

--- a/eth/sequencer/pending_head_fallback_test.go
+++ b/eth/sequencer/pending_head_fallback_test.go
@@ -1,0 +1,71 @@
+package sequencer
+
+import (
+	"testing"
+
+	"github.com/0xPolygon/sequence-store-proto/commitment"
+)
+
+// HeadPendingView is the last-resort pending view a non-mining RPC node serves
+// in the window between importing a block and receiving the producer's open
+// for the next height, when no preconf entry is active and there is no miner
+// to fall back to. It must be an empty block on head+1 carrying the head
+// state — the correct pending answer while nothing is preconfirmed. Before
+// this fix such a node answered -32000 "pending state is not available" for
+// ~150ms every block, breaking bind's default eth_getCode(addr,"pending").
+func TestHeadPendingViewServesEmptyHeadState(t *testing.T) {
+	h := startExecHarness(t)
+	c := &Consumer{chain: h.chain, index: NewIndex()}
+	head := h.chain.CurrentBlock()
+
+	block, receipts, statedb, err := c.HeadPendingView()
+	if err != nil {
+		t.Fatalf("HeadPendingView error: %v", err)
+	}
+	if block == nil || statedb == nil {
+		t.Fatal("head pending view unavailable: the -32000 regression")
+	}
+	if got, want := block.NumberU64(), head.Number.Uint64()+1; got != want {
+		t.Fatalf("pending number = %d, want head+1 = %d", got, want)
+	}
+	if block.ParentHash() != head.Hash() {
+		t.Fatalf("pending parent = %s, want head %s", block.ParentHash(), head.Hash())
+	}
+	if len(block.Transactions()) != 0 || len(receipts) != 0 {
+		t.Fatalf("gap pending must be empty, got %d txs %d receipts",
+			len(block.Transactions()), len(receipts))
+	}
+	if statedb.GetBalance(h.addr).IsZero() {
+		t.Fatal("served state is not the head state: funded genesis account missing")
+	}
+}
+
+// The head view is a pure fallback: it reflects only the head state and never
+// leaks a live preconf entry's transactions. Preferring the live preconf view
+// is the eth backend's job (it consults PendingSnapshot first); HeadPendingView
+// stays empty so it can never shadow preconfirmed content.
+func TestHeadPendingViewIgnoresActivePreconf(t *testing.T) {
+	h := startExecHarness(t)
+	session := h.session()
+	c := session.consumer
+
+	cur := handleOK(t, session, openOn(h.chain.CurrentBlock(), h.config, commitment.Head{0x41}))
+	raw, err := h.transfer(t, 0).MarshalBinary()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	handleOK(t, session, recordEntry(raw, cur))
+	publishPendingSnapshot(t, session)
+
+	// The live view carries the preconf tx.
+	live, _, _, err := c.PendingSnapshot(t.Context())
+	if err != nil || live == nil || len(live.Transactions()) != 1 {
+		t.Fatalf("live preconf view = %v err=%v", live, err)
+	}
+
+	// The head fallback stays empty regardless.
+	fallback, _, _, err := c.HeadPendingView()
+	if err != nil || fallback == nil || len(fallback.Transactions()) != 0 {
+		t.Fatalf("head fallback leaked preconf content: %v err=%v", fallback, err)
+	}
+}

--- a/eth/sequencer/pending_rpc.go
+++ b/eth/sequencer/pending_rpc.go
@@ -2,8 +2,10 @@ package sequencer
 
 import (
 	"context"
+	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/consensus/misc/eip1559"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 )
@@ -23,6 +25,51 @@ func (c *Consumer) PendingSnapshot(ctx context.Context) (*types.Block, types.Rec
 		return nil, nil, nil, nil
 	}
 	return block, receipts, statedb, nil
+}
+
+// HeadPendingView is an empty pending block on the head, the last-resort view
+// for a non-mining RPC node in the import->next-open gap when no preconf entry
+// is active. Without it such a node answers -32000 for ~150ms every block,
+// breaking bind's default eth_getCode(addr,"pending"). The backend tries it
+// only after the live view and the miner, so it never shadows either.
+func (c *Consumer) HeadPendingView() (*types.Block, types.Receipts, *state.StateDB, error) {
+	anchor, ok := c.pendingReadAnchor()
+	if !ok {
+		return nil, nil, nil, nil
+	}
+	block, receipts, statedb, err := c.headPendingView(anchor)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	if !c.pendingReadAnchorValid(anchor) {
+		return nil, nil, nil, nil
+	}
+	return block, receipts, statedb, nil
+}
+
+// headPendingView builds the empty head+1 block on the head state, or nil when
+// the head or its state is unavailable.
+func (c *Consumer) headPendingView(head *types.Header) (*types.Block, types.Receipts, *state.StateDB, error) {
+	if head == nil || c.chain == nil {
+		return nil, nil, nil, nil
+	}
+	statedb, err := c.chain.StateAt(head.Root)
+	if err != nil || statedb == nil {
+		return nil, nil, nil, nil
+	}
+	number := new(big.Int).Add(head.Number, big.NewInt(1))
+	header := &types.Header{
+		ParentHash: head.Hash(),
+		Number:     number,
+		GasLimit:   head.GasLimit,
+		Time:       head.Time + 1,
+		Difficulty: big.NewInt(1),
+		Root:       head.Root,
+	}
+	if config := c.chain.Config(); config.IsLondon(number) {
+		header.BaseFee = eip1559.CalcBaseFee(config, head)
+	}
+	return types.NewBlockWithHeader(header), types.Receipts{}, statedb, nil
 }
 
 func (c *Consumer) PendingBlock() *types.Block {


### PR DESCRIPTION
## Summary

Non-mining RPC nodes with the sequence store enabled answer `-32000 pending state is not available` for ~150 ms after every block import. At import, `CompletePreconf` removes the pending entry (`hasActive = false`); until the producer's open for the next height arrives, the consumer has no active entry and an RPC node has no miner to fall back to, so `EthAPIBackend.PendingSnapshot` errors. `go-ethereum` bind issues `eth_getCode(addr, "pending")` before gas estimation by default, so Go applications on default settings saw intermittent transaction-send failures against these nodes (~11–13% of pending calls). Reported by John Hilliard.

The fix serves an empty pending block on the head with the head state during the gap — stock non-mining geth behavior, and the correct pending answer while nothing is preconfirmed (it is exactly the base the next open installs). `Consumer.HeadPendingView` builds it. The eth backend consults it **only after** the consumer's live view and the miner both yield nothing, so:

- **Producers are untouched** — their miner pending still serves the gap.
- **A live preconf view is never shadowed** — the backend prefers `PendingSnapshot`, and `HeadPendingView` stays empty even when an entry is active.

Both surfaces are covered:
- **State path** (`PendingSnapshot`): `eth_getCode`, `eth_call`, `eth_getBalance`, `eth_getStorageAt`, `eth_estimateGas`, `eth_getProof`, `eth_createAccessList` for `"pending"`.
- **Block path** (`PendingBlock` / `PendingBlockAndReceipts`): `eth_getBlockByNumber`, `eth_getHeaderByNumber`, `eth_getBlockReceipts`, and the count/index siblings for `"pending"`.

`eth_getTransactionCount(addr, "pending")` was already gap-safe (txpool-backed) and pending log filters correctly return empty during the gap; no other pending endpoint returned `-32000`.

| Probe (kurtosis devnet, `bor` @ a2adc08cc RPC node) | Before | After |
| --- | --- | --- |
| `eth_getCode(…, "pending")` error rate over 60 s | 12.6% / 10.7% | **0.0%** (0 / 6134) |
| `eth_getBlockByNumber("pending")` in the gap | `null` | **never null** (always head+1) |

## Executed tests

- `go test ./eth/sequencer/` and `go test ./eth/` — green.
- New unit tests: `TestHeadPendingViewServesEmptyHeadState`, `TestHeadPendingViewIgnoresActivePreconf` (consumer), `TestSequencerPendingSnapshotHeadFallback` (backend ordering, state + block accessors). Each revert-checked to fail on the pre-fix behavior.
- Reproduced on a kurtosis devnet with a `kind: rpc` node: John's exact `eth_getCode(0xca11…ca11, "pending")` probe went from 12.6%/10.7% to 0%, and `eth_getBlockByNumber("pending")` no longer returns null in the gap.

## Rollout notes

Not consensus-affecting — RPC-serving behavior only, and only on non-mining sequencer RPC nodes during the import→next-open window. No coordinated upgrade required. The served pending block is an empty block on the current head (head state, head+1 number, EIP-1559 base fee), which is what a non-mining geth node returns for `pending`.
