### PR TITLE
eth: preserve preconfirmation RPC availability

### DIFF
--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -836,6 +836,18 @@ func (b *EthAPIBackend) PreconfEnabled() bool {
 	return b.relay.PreconfEnabled()
 }
 func (b *EthAPIBackend) SubmitTxForPreconf(tx *types.Transaction) error {
+	if b.eth != nil {
+		if consumer, ok := b.eth.seqConsumer.(interface {
+			CachePreconfTransaction(*types.Transaction) error
+		}); ok {
+			if err := consumer.CachePreconfTransaction(tx); err != nil {
+				return err
+			}
+		}
+	}
+	if !b.relay.PreconfRelayAvailable() {
+		return nil
+	}
 	return b.relay.SubmitPreconfTransaction(tx)
 }
 

--- a/eth/api_backend_test.go
+++ b/eth/api_backend_test.go
@@ -319,8 +319,6 @@ func TestRelayMethodWiring(t *testing.T) {
 
 	t.Run("submit and check methods reach relay", func(t *testing.T) {
 		t.Parallel()
-		// Init with enablePreconf=true, enablePrivateTx=true but no URLs
-		// → txRelay created with nil multiclient → methods return errors, proving wiring works
 		rs := relay.Init(true, true, false, false, nil)
 		defer rs.Close()
 		b := &EthAPIBackend{relay: rs}
@@ -328,7 +326,7 @@ func TestRelayMethodWiring(t *testing.T) {
 		tx := types.NewTransaction(0, common.Address{}, nil, 0, nil, nil)
 
 		err := b.SubmitTxForPreconf(tx)
-		require.Error(t, err, "SubmitTxForPreconf should return error with nil multiclient")
+		require.NoError(t, err, "SubmitTxForPreconf should be optional without producer endpoints")
 
 		_, err = b.CheckPreconfStatus(common.Hash{})
 		require.Error(t, err, "CheckPreconfStatus should return error with nil multiclient")

--- a/eth/relay/relay.go
+++ b/eth/relay/relay.go
@@ -100,6 +100,10 @@ func (s *RelayService) PreconfEnabled() bool {
 	return s.config.enablePreconf
 }
 
+func (s *RelayService) PreconfRelayAvailable() bool {
+	return s.txRelay != nil && s.txRelay.multiclient != nil
+}
+
 func (s *RelayService) PrivateTxEnabled() bool {
 	return s.config.enablePrivateTx
 }

--- a/eth/relay/relay_test.go
+++ b/eth/relay/relay_test.go
@@ -89,9 +89,16 @@ func TestConfigAccessors(t *testing.T) {
 	defer rs.Close()
 
 	require.True(t, rs.PreconfEnabled(), "expected PreconfEnabled to be true")
+	require.False(t, rs.PreconfRelayAvailable(), "expected preconf relay to be unavailable")
 	require.False(t, rs.PrivateTxEnabled(), "expected PrivateTxEnabled to be false")
 	require.True(t, rs.AcceptPreconfTxs(), "expected AcceptPreconfTxs to be true")
 	require.False(t, rs.AcceptPrivateTxs(), "expected AcceptPrivateTxs to be false")
+
+	server := newMockRpcServer()
+	defer server.close()
+	withProducer := Init(true, false, false, false, []string{server.server.URL})
+	defer withProducer.Close()
+	require.True(t, withProducer.PreconfRelayAvailable(), "expected preconf relay to be available")
 }
 
 func TestRelaySubmitPreconfTransaction(t *testing.T) {

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -2278,17 +2278,11 @@ func (api *TransactionAPI) SendRawTransactionSync(ctx context.Context, input hex
 }
 
 func (api *TransactionAPI) submitSyncTransaction(ctx context.Context, tx *types.Transaction) (common.Hash, bool, error) {
-	if submitter, ok := api.b.(preconfSyncSubmitter); ok && api.b.PreconfEnabled() {
-		if err := submitter.SubmitTxForPreconfSync(ctx, tx); err != nil {
-			return common.Hash{}, false, err
-		}
-		return tx.Hash(), true, nil
-	}
 	hash, err := SubmitTransaction(ctx, api.b, tx)
 	if err == nil {
 		api.submitForPreconf(tx)
 	}
-	return hash, false, err
+	return hash, api.b.PreconfEnabled(), err
 }
 
 // txSyncTimeout resolves the caller's requested wait window against the node's

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -5354,9 +5354,49 @@ func TestSendRawTransactionSync_Preconfirmation(t *testing.T) {
 	if receipt == nil || receipt["transactionHash"] != tx.Hash() || receipt["blockHash"] != nil || receipt["preconfirmation"] != true {
 		t.Fatalf("preconfirmation receipt = %#v", receipt)
 	}
-	if b.sentTx != nil {
-		t.Fatalf("transaction was also submitted to the local txpool")
+	if b.sentTx == nil || b.sentTx.Hash() != tx.Hash() {
+		t.Fatalf("transaction was not submitted to the local txpool")
 	}
+}
+
+func TestSendRawTransactionSync_RelayIsOptional(t *testing.T) {
+	t.Parallel()
+	genesis := &core.Genesis{Config: params.TestChainConfig, Alloc: types.GenesisAlloc{}}
+	b := newTestBackend(t, 0, genesis, ethash.NewFaker(), nil)
+	b.preconfEnabled = true
+	b.submitTxForPreconfFn = func(tx *types.Transaction) error {
+		go func() {
+			time.Sleep(20 * time.Millisecond)
+			receipt := &types.Receipt{
+				Type:              tx.Type(),
+				Status:            types.ReceiptStatusSuccessful,
+				CumulativeGasUsed: tx.Gas(),
+				GasUsed:           tx.Gas(),
+				EffectiveGasPrice: tx.GasPrice(),
+				TxHash:            tx.Hash(),
+				BlockNumber:       new(big.Int).Add(b.CurrentBlock().Number, common.Big1),
+			}
+			b.preconf.mu.Lock()
+			b.preconf.tx = tx
+			b.preconf.receipt = receipt
+			b.preconf.mu.Unlock()
+			b.preconfFeed.Send(core.PreconfReceiptsEvent{
+				BlockTime:    b.CurrentBlock().Time + 1,
+				Receipts:     types.Receipts{receipt},
+				Transactions: types.Transactions{tx},
+			})
+		}()
+		return errors.New("rpc client unavailable to submit transactions")
+	}
+	api := NewTransactionAPI(b, new(AddrLocker))
+	raw, tx := makeSelfSignedRaw(t, api, b.acc.Address)
+	timeout := hexutil.Uint64(500)
+
+	receipt, err := api.SendRawTransactionSync(t.Context(), raw, &timeout)
+	require.NoError(t, err)
+	require.Equal(t, tx.Hash(), receipt["transactionHash"])
+	require.Nil(t, receipt["blockHash"])
+	require.Equal(t, true, receipt["preconfirmation"])
 }
 
 func TestSendRawTransactionSync_PrefersQueuedPreconfirmation(t *testing.T) {

--- a/internal/ethapi/preconf_receipt.go
+++ b/internal/ethapi/preconf_receipt.go
@@ -1,8 +1,6 @@
 package ethapi
 
 import (
-	"context"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -15,10 +13,6 @@ type preconfBackend interface {
 
 type preconfReceiptSubscriber interface {
 	SubscribePreconfReceipts(chan<- core.PreconfReceiptsEvent) event.Subscription
-}
-
-type preconfSyncSubmitter interface {
-	SubmitTxForPreconfSync(context.Context, *types.Transaction) error
 }
 
 func getPreconfTransaction(backend Backend, hash common.Hash) (*types.Transaction, *types.Receipt, bool) {


### PR DESCRIPTION
## Summary

This PR fixes `eth_sendRawTransactionSync` when preconfirmations are enabled but the RPC node has no direct block-producer endpoints configured.

The synchronous path now submits the transaction to the local txpool first, allowing normal P2P propagation to the block producer. It then waits for either a speculative preconfirmation receipt or the canonical receipt. Direct relay submission remains optional and is used only when `bp-rpc-endpoints` is configured.

This prevents `eth_sendRawTransactionSync` from failing with `request dropped: rpc client unavailable to submit transactions` on standard RPC and sentry nodes.

The change is intentionally limited to transaction submission and receipt waiting. It does not modify pending-block construction, `PendingBlockAndReceipts`, pending-state RPC behavior, block import, or consensus processing.

## Executed tests

```text
go test ./internal/ethapi ./eth/relay ./eth -count=1
PASS

go test -race ./internal/ethapi \
  -run 'TestSendRawTransactionSync_(Preconfirmation|RelayIsOptional)$' \
  -count=1
PASS

go test -race ./eth/relay \
  -run 'TestConfigAccessors$' \
  -count=1
PASS

make lint
PASS — 0 issues

git diff --check
PASS
```

Manual Kurtosis validation was also performed against an RPC node with preconfirmations enabled and no `bp-rpc-endpoints`.

A transaction submitted using `cast send --sync` returned a successful speculative receipt with `blockHash: null`. The same transaction was subsequently available as a canonical receipt with a populated block hash.

## Rollout notes

This change is consensus-neutral and does not alter block execution, validation, import, or fork choice.

No database migration, resync, or coordinated network upgrade is required. The change is backward-compatible for nodes with direct producer endpoints configured.

RPC nodes no longer require `bp-rpc-endpoints` for `eth_sendRawTransactionSync` to function. Without those endpoints, transactions propagate through the local txpool and normal P2P networking. When producer endpoints are configured, the existing direct relay path remains available.