### PR TITLE
eth/downloader/whitelist: bound fork-check slice preallocation

### DIFF
--- a/eth/downloader/whitelist/service.go
+++ b/eth/downloader/whitelist/service.go
@@ -29,6 +29,10 @@ var (
 	DefaultMaxForkCorrectnessLimit = uint64(256)
 )
 
+func forkValidationInitialCapacity(limit uint64) uint64 {
+	return min(limit, 2*DefaultMaxForkCorrectnessLimit)
+}
+
 type Service struct {
 	db ethdb.Database
 	checkpointService
@@ -271,8 +275,10 @@ func (s *Service) checkForkCorrectness(chain []*types.Header) bool {
 		return true
 	}
 
-	// Track all blocks iterated for caching
-	var blocksChecked []common.Hash = make([]common.Hash, 0, s.maxForkCorrectnessLimit)
+	// Track all blocks iterated for caching. Keep the configured traversal limit
+	// unchanged, but bound the initial allocation to avoid oversized preallocation.
+	blocksCheckedCapacity := forkValidationInitialCapacity(s.maxForkCorrectnessLimit)
+	blocksChecked := make([]common.Hash, 0, blocksCheckedCapacity)
 	// Cache the incoming chain by default
 	for _, header := range chain {
 		blocksChecked = append(blocksChecked, header.Hash())

--- a/eth/downloader/whitelist/service_large_limit_test.go
+++ b/eth/downloader/whitelist/service_large_limit_test.go
@@ -1,0 +1,35 @@
+package whitelist
+
+import (
+	"math"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/stretchr/testify/require"
+)
+
+func TestForkValidationInitialCapacity(t *testing.T) {
+	require.Equal(t, 2*DefaultMaxForkCorrectnessLimit, forkValidationInitialCapacity(math.MaxUint64))
+	require.Equal(t, uint64(128), forkValidationInitialCapacity(128))
+}
+
+func TestCheckForkCorrectnessLargeLimit(t *testing.T) {
+	db := rawdb.NewMemoryDatabase()
+	service := NewService(db, false, math.MaxUint64)
+
+	parent := createMockChain(1, 1, common.Hash{})[0]
+	rawdb.WriteHeader(db, parent)
+	chain := createMockChain(2, 2, parent.Hash())
+	service.ProcessCheckpoint(parent.Number.Uint64(), parent.Hash())
+
+	// The configured traversal limit remains unchanged. Only the initial
+	// blocksChecked allocation is bounded.
+	require.Equal(t, uint64(math.MaxUint64), service.maxForkCorrectnessLimit)
+
+	var valid bool
+	require.NotPanics(t, func() {
+		valid = service.checkForkCorrectness(chain)
+	})
+	require.True(t, valid)
+}


### PR DESCRIPTION
## Summary

Bound the initial capacity of `blocksChecked` in `checkForkCorrectness` to the same 2x-default size already used for the fork validation cache.

`max-blind-fork-validation-limit` remains the actual traversal limit. This change only avoids eagerly preallocating a slice directly from unusually large configured values; the slice can still grow normally when more entries are actually visited.

A regression test covers a very large configured limit and verifies that fork correctness checking continues normally while preserving the configured traversal limit.

## Executed tests

A focused Go runtime reproducer was used to confirm the oversized-capacity behavior. The full Bor test suite was not run locally because the repository could not be cloned from this environment; CI is expected to run the repository's standard checks.

## Rollout notes

Backwards-compatible, non-consensus behavior change. Default configuration behavior is unchanged. No coordinated upgrade is required; this only bounds an internal initial allocation.