### PR TITLE
eth/downloader/whitelist: keep valid result meters monotonic

### DIFF
--- a/eth/downloader/whitelist/checkpoint.go
+++ b/eth/downloader/whitelist/checkpoint.go
@@ -19,7 +19,7 @@ var (
 	//Metrics for collecting the whitelisted milestone number
 	whitelistedCheckpointNumberMeter = metrics.NewRegisteredGauge("chain/checkpoint/latest", nil)
 
-	//Metrics for collecting the number of invalid chains received
+	//Metrics for collecting the number of valid chains received
 	CheckpointChainMeter = metrics.NewRegisteredMeter("chain/checkpoint/isvalidchain", nil)
 
 	//Metrics for collecting the number of valid peers received
@@ -39,20 +39,12 @@ func (w *checkpoint) IsValidChain(currentHeader *types.Header, chain []*types.He
 }
 
 func reportCheckpointMetrics(result bool, chain bool, peer bool) {
-	if chain {
-		if result {
-			CheckpointChainMeter.Mark(int64(1))
-		} else {
-			CheckpointChainMeter.Mark(int64(-1))
-		}
+	if chain && result {
+		CheckpointChainMeter.Mark(int64(1))
 	}
 
-	if peer {
-		if result {
-			CheckpointPeerMeter.Mark(int64(1))
-		} else {
-			CheckpointPeerMeter.Mark(int64(-1))
-		}
+	if peer && result {
+		CheckpointPeerMeter.Mark(int64(1))
 	}
 }
 

--- a/eth/downloader/whitelist/metrics_test.go
+++ b/eth/downloader/whitelist/metrics_test.go
@@ -1,0 +1,106 @@
+package whitelist
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+func TestCheckpointInvalidMetricsDoNotDecrementValidMeters(t *testing.T) {
+	chainBefore := CheckpointChainMeter.Snapshot().Count()
+	peerBefore := CheckpointPeerMeter.Snapshot().Count()
+
+	reportCheckpointMetrics(false, true, false)
+	reportCheckpointMetrics(false, false, true)
+
+	if got := CheckpointChainMeter.Snapshot().Count() - chainBefore; got != 0 {
+		t.Fatalf("invalid checkpoint chain changed valid meter by %d", got)
+	}
+	if got := CheckpointPeerMeter.Snapshot().Count() - peerBefore; got != 0 {
+		t.Fatalf("invalid checkpoint peer changed valid meter by %d", got)
+	}
+}
+
+func TestMilestoneMetricsOnlyCountValidResults(t *testing.T) {
+	db := rawdb.NewMemoryDatabase()
+	svc := NewService(db, false, 0)
+
+	m, ok := svc.milestoneService.(*milestone)
+	if !ok {
+		t.Fatalf("expected milestoneService to be *milestone, got %T", svc.milestoneService)
+	}
+
+	chain := []*types.Header{{Number: big.NewInt(10)}}
+
+	// Force the chain through the locked-milestone rejection path.
+	m.finality.Lock()
+	m.Locked = true
+	m.LockedMilestoneNumber = 10
+	m.LockedMilestoneHash = common.Hash{0x01}
+	m.finality.Unlock()
+
+	chainBefore := MilestoneChainMeter.Snapshot().Count()
+	valid, err := m.IsValidChain(chain[0], chain)
+	if err != nil {
+		t.Fatalf("unexpected invalid-chain error: %v", err)
+	}
+	if valid {
+		t.Fatal("expected chain to be rejected by locked milestone")
+	}
+	if got := MilestoneChainMeter.Snapshot().Count() - chainBefore; got != 0 {
+		t.Fatalf("invalid milestone chain changed valid meter by %d", got)
+	}
+
+	// A valid result must still increment the valid-chain meter.
+	m.finality.Lock()
+	m.Locked = false
+	m.finality.Unlock()
+
+	chainBefore = MilestoneChainMeter.Snapshot().Count()
+	valid, err = m.IsValidChain(chain[0], chain)
+	if err != nil {
+		t.Fatalf("unexpected valid-chain error: %v", err)
+	}
+	if !valid {
+		t.Fatal("expected chain to be valid")
+	}
+	if got := MilestoneChainMeter.Snapshot().Count() - chainBefore; got != 1 {
+		t.Fatalf("valid milestone chain changed valid meter by %d, want 1", got)
+	}
+
+	// Seed a milestone so peer validation compares the returned hash.
+	expectedHash := common.Hash{0x01}
+	m.Process(10, expectedHash)
+
+	peerBefore := MilestonePeerMeter.Snapshot().Count()
+	valid, err = m.IsValidPeer(func(number uint64, amount int, skip int, reverse bool) ([]*types.Header, []common.Hash, error) {
+		return []*types.Header{{Number: big.NewInt(10)}}, []common.Hash{{0x02}}, nil
+	})
+	if valid {
+		t.Fatal("expected peer with mismatching milestone hash to be invalid")
+	}
+	if err == nil {
+		t.Fatal("expected mismatching peer to return an error")
+	}
+	if got := MilestonePeerMeter.Snapshot().Count() - peerBefore; got != 0 {
+		t.Fatalf("invalid milestone peer changed valid meter by %d", got)
+	}
+
+	// A matching peer must still increment the valid-peer meter.
+	peerBefore = MilestonePeerMeter.Snapshot().Count()
+	valid, err = m.IsValidPeer(func(number uint64, amount int, skip int, reverse bool) ([]*types.Header, []common.Hash, error) {
+		return []*types.Header{{Number: big.NewInt(10)}}, []common.Hash{expectedHash}, nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected valid-peer error: %v", err)
+	}
+	if !valid {
+		t.Fatal("expected peer with matching milestone hash to be valid")
+	}
+	if got := MilestonePeerMeter.Snapshot().Count() - peerBefore; got != 1 {
+		t.Fatalf("valid milestone peer changed valid meter by %d, want 1", got)
+	}
+}

--- a/eth/downloader/whitelist/milestone.go
+++ b/eth/downloader/whitelist/milestone.go
@@ -79,8 +79,6 @@ func (m *milestone) IsValidChain(currentHeader *types.Header, chain []*types.Hea
 	defer func() {
 		if isValid {
 			MilestoneChainMeter.Mark(int64(1))
-		} else {
-			MilestoneChainMeter.Mark(int64(-1))
 		}
 	}()
 
@@ -138,8 +136,6 @@ func (m *milestone) IsValidPeer(fetchHeadersByNumber func(number uint64, amount 
 
 	if res {
 		MilestonePeerMeter.Mark(int64(1))
-	} else {
-		MilestonePeerMeter.Mark(int64(-1))
 	}
 
 	return res, err


### PR DESCRIPTION
## Summary

Keep checkpoint and milestone validity meters monotonic by recording only successful validation results.

The existing `chain/checkpoint/isvalid*` and `chain/milestone/isvalid*` meters are documented as counts of valid chains/peers, but invalid results currently call `Mark(-1)`, which subtracts from those counters. This change leaves the existing metric names and successful-result behavior unchanged while avoiding counter decrements on invalid results.

A focused regression test verifies that invalid checkpoint chain/peer results do not change the valid-result meters.

## Executed tests

Reviewed the meter implementation to confirm that `Mark(n)` adds `n` directly to the meter count, including negative values. Added a focused regression test covering invalid checkpoint chain and peer metric updates.

The full Bor test suite was not run locally in this environment; CI is expected to run the repository's standard checks.

## Rollout notes

Observability-only change. No consensus, protocol, fork-choice, validation, or operator configuration behavior is changed. Existing metric names remain unchanged.