### PR TITLE
eth, core/state: self-heal missing contract code on stateless import

### DIFF
--- a/core/error.go
+++ b/core/error.go
@@ -39,6 +39,16 @@ var (
 	// self-validation.
 	ErrStatelessStateRootMismatch = errors.New("stateless self-validation state root mismatch")
 
+	// ErrStatelessIncompleteState indicates that stateless execution could not
+	// load a piece of state or contract code it required: the witness omitted a
+	// trie node the block accesses, or a called contract's bytecode was absent
+	// from local disk (WIT2 witnesses do not carry code). StateDB records such a
+	// miss as a sticky error and nil-serves the read, so execution continues
+	// against phantom-zero state; the divergence would otherwise surface only as
+	// a misleading ErrGasUsedMismatch (or a state root mismatch). It is detected
+	// explicitly so the block is rejected with its true cause instead.
+	ErrStatelessIncompleteState = errors.New("stateless execution hit incomplete state or code")
+
 	// ErrGasUsedMismatch indicates a mismatch between locally computed
 	// gas used and the block's gas used during validation.
 	ErrGasUsedMismatch = errors.New("invalid gas used")

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -636,6 +636,25 @@ func (s *stateObject) Address() common.Address {
 	return s.address
 }
 
+// MissingCodeError is recorded via StateDB.setError when contract code for a
+// non-empty code hash cannot be found in the backing store during execution.
+// On the stateless path code lives on local disk (WIT2 witnesses carry no
+// code), so this identifies a fetchable gap: the blob is content-addressed by
+// Hash and can be re-fetched from a peer and re-persisted. It is deliberately
+// distinct from a missing state trie node, which signals an incomplete witness
+// (not absent code) and is not fetchable by code hash.
+type MissingCodeError struct {
+	Addr common.Address
+	Hash common.Hash
+}
+
+// Error keeps the historical "code is not found <hash>" wording (asserted by
+// witness-regen fixtures) so the message is unchanged; the type is what lets
+// callers recover the hash via errors.As.
+func (e *MissingCodeError) Error() string {
+	return fmt.Sprintf("code is not found %x", e.Hash)
+}
+
 // Code returns the contract code associated with this object, if any.
 func (s *stateObject) Code() []byte {
 	if len(s.code) != 0 {
@@ -652,7 +671,7 @@ func (s *stateObject) Code() []byte {
 	}
 	if len(code) == 0 {
 		log.Error("Code is not found", "address", s.address, "hash", fmt.Sprintf("%x", s.CodeHash()))
-		s.db.setError(fmt.Errorf("code is not found %x", s.CodeHash()))
+		s.db.setError(&MissingCodeError{Addr: s.address, Hash: common.BytesToHash(s.CodeHash())})
 	}
 	s.code = code
 
@@ -675,7 +694,7 @@ func (s *stateObject) CodeSize() int {
 		s.db.setError(fmt.Errorf("can't load code size %x: %v", s.CodeHash(), err))
 	}
 	if size == 0 {
-		s.db.setError(fmt.Errorf("code is not found %x", s.CodeHash()))
+		s.db.setError(&MissingCodeError{Addr: s.address, Hash: common.BytesToHash(s.CodeHash())})
 	}
 	return size
 }

--- a/core/stateless.go
+++ b/core/stateless.go
@@ -97,7 +97,7 @@ func ExecuteStateless(config *params.ChainConfig, vmconfig vm.Config, block *typ
 		statelessIncompleteStateMeter.Mark(1)
 		log.Error("stateless execution hit incomplete state or code; rejecting block",
 			"block", block.Number(), "hash", block.Hash(), "err", dbErr, "procErr", err)
-		return common.Hash{}, common.Hash{}, db, res, fmt.Errorf("%w: %v", ErrStatelessIncompleteState, dbErr)
+		return common.Hash{}, common.Hash{}, db, res, fmt.Errorf("%w: %w", ErrStatelessIncompleteState, dbErr)
 	}
 	if err != nil {
 		return common.Hash{}, common.Hash{}, nil, nil, err

--- a/core/stateless.go
+++ b/core/stateless.go
@@ -18,6 +18,7 @@ package core
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/lru"
@@ -28,10 +29,18 @@ import (
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/trie"
 	"github.com/ethereum/go-ethereum/triedb"
 )
+
+// statelessIncompleteStateMeter counts blocks rejected because stateless
+// execution could not load required state or contract code (see
+// ErrStatelessIncompleteState). A non-zero rate on a stateless node signals a
+// witness-completeness or bytecode-heal gap rather than genuine consensus
+// divergence.
+var statelessIncompleteStateMeter = metrics.NewRegisteredMeter("chain/stateless/incomplete_state", nil)
 
 // ExecuteStateless runs a stateless execution based on a witness, verifies
 // everything it can locally and returns the state root and receipt root, that
@@ -68,6 +77,28 @@ func ExecuteStateless(config *params.ChainConfig, vmconfig vm.Config, block *typ
 	validator := NewBlockValidator(config, nil) // No chain, we only validate the state, not the block
 
 	res, err := processor.Process(block, db, vmconfig, author, context.Background())
+
+	// A missing witness trie node, or a called contract's bytecode absent from
+	// local disk (WIT2 witnesses do not carry code), is caught by StateDB
+	// (state/statedb.go's setError/dbErr) but only recorded as a sticky flag —
+	// it never halts execution, so the read silently nil-serves and execution
+	// continues against phantom-zero state. That can either flow into a wrong
+	// gas result (surfacing only as a misleading ErrGasUsedMismatch, or a state
+	// root mismatch on the full path) or push the divergent execution into a
+	// secondary failure — e.g. "gas limit reached" — that Process returns as its
+	// own error, masking the true cause. In both cases db.Error() names the real
+	// problem, so check it FIRST and prefer it over any Process error: the
+	// computed result is untrustworthy the moment a required read could not be
+	// served. The test-only serial replay (executeStatelessSerial) already gates
+	// on db.Error() this way; this makes the production path do the same. db/res
+	// are preserved so callers doing forensic capture still see the computed
+	// (wrong) result, not just the error string.
+	if dbErr := db.Error(); dbErr != nil {
+		statelessIncompleteStateMeter.Mark(1)
+		log.Error("stateless execution hit incomplete state or code; rejecting block",
+			"block", block.Number(), "hash", block.Hash(), "err", dbErr, "procErr", err)
+		return common.Hash{}, common.Hash{}, db, res, fmt.Errorf("%w: %v", ErrStatelessIncompleteState, dbErr)
+	}
 	if err != nil {
 		return common.Hash{}, common.Hash{}, nil, nil, err
 	}

--- a/core/stateless_missing_code_test.go
+++ b/core/stateless_missing_code_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -112,6 +113,16 @@ func TestExecuteStatelessRejectsMissingCode(t *testing.T) {
 			t.Fatalf("removing read code %x produced %v, want ErrStatelessIncompleteState", h, err)
 		case !strings.Contains(err.Error(), strings.TrimPrefix(h.Hex(), "0x")):
 			t.Fatalf("error for missing code %x does not name the hash: %v", h, err)
+		}
+
+		// The missing code hash must be machine-recoverable (not just in the
+		// message) so the downloader self-heal can fetch exactly that blob.
+		var mce *state.MissingCodeError
+		if !errors.As(err, &mce) {
+			t.Fatalf("error for missing code %x is not a *state.MissingCodeError: %v", h, err)
+		}
+		if mce.Hash != h {
+			t.Fatalf("MissingCodeError.Hash = %x, want %x", mce.Hash, h)
 		}
 
 		if tested++; testing.Short() && tested >= 1 {

--- a/core/stateless_missing_code_test.go
+++ b/core/stateless_missing_code_test.go
@@ -1,0 +1,121 @@
+// Copyright 2024 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package core
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/params"
+)
+
+// codeReadRecorder wraps the code-backing disk database and records which
+// contract-code blobs stateless execution actually reads. A code read is a Get
+// whose value hashes to the 32-byte tail of its key (rawdb stores code under
+// codePrefix||codeHash), so this identifies code reads without depending on the
+// unexported prefix. It lets the test target only the handful of contracts this
+// block depends on rather than sweeping every blob in the shared fixture.
+type codeReadRecorder struct {
+	ethdb.Database
+	reads map[common.Hash]struct{}
+}
+
+func (r *codeReadRecorder) Get(key []byte) ([]byte, error) {
+	v, err := r.Database.Get(key)
+	if err == nil && len(key) >= common.HashLength && len(v) > 0 {
+		if tail := common.BytesToHash(key[len(key)-common.HashLength:]); crypto.Keccak256Hash(v) == tail {
+			r.reads[tail] = struct{}{}
+		}
+	}
+	return v, err
+}
+
+// TestExecuteStatelessRejectsMissingCode proves that when a called contract's
+// bytecode is absent from local disk, the production stateless path rejects the
+// block with ErrStatelessIncompleteState naming the missing hash — instead of
+// silently running the contract as code-less and surfacing the divergence only
+// as a misleading ErrGasUsedMismatch.
+//
+// This is the exact condition behind the bor mainnet-soak gas-mismatch
+// incident: WIT2 witnesses do not carry code, so a stateless node reads code
+// from its own disk; when the bytecode-heal/fast-forward accounting left a
+// called contract's code absent, StateDB recorded a sticky error and nil-served
+// the read, and nothing on the stateless path consulted db.Error(). The
+// test-only serial replay (executeStatelessSerial) already gates on db.Error();
+// this asserts the production ExecuteStateless now does the same.
+func TestExecuteStatelessRejectsMissingCode(t *testing.T) {
+	bd, diskdb := loadSingleWitnessRegenBlock(t, singleRegenBlockHex)
+	config := params.BorMainnetChainConfig
+	engine := &benchConsensus{}
+	pb := prepareBlocks([]testBlockData{bd}, diskdb, config)[0]
+
+	// Reproduce ProcessBlockWithWitnesses' prelude: hand ExecuteStateless a
+	// block with the roots it is expected to recompute zeroed out.
+	newTask := func() *types.Block {
+		ctx := pb.block.Header()
+		ctx.Root = common.Hash{}
+		ctx.ReceiptHash = common.Hash{}
+		return types.NewBlockWithHeader(ctx).WithBody(*pb.block.Body())
+	}
+
+	// Baseline through the recorder: with all code present the block verifies
+	// cleanly, and we capture exactly which code blobs it reads.
+	rec := &codeReadRecorder{Database: diskdb, reads: make(map[common.Hash]struct{})}
+	if _, _, _, _, err := ExecuteStateless(config, vm.Config{}, newTask(), pb.witness, &pb.author, engine, rec); err != nil {
+		t.Fatalf("baseline ExecuteStateless with complete code failed: %v", err)
+	}
+	if len(rec.reads) == 0 {
+		t.Fatal("fixture block reads no contract code; cannot exercise the guard")
+	}
+
+	// Removing any code the block reads must surface as
+	// ErrStatelessIncompleteState naming the hash — never a bare gas/root
+	// mismatch, a Process-level symptom like "gas limit reached", or a silent
+	// pass. Each removal is a full serial replay, so cap the sweep in -short.
+	tested := 0
+	for h := range rec.reads {
+		code := rawdb.ReadCode(diskdb, h)
+		if len(code) == 0 {
+			t.Fatalf("recorded code %x is not present to remove", h)
+		}
+		rawdb.DeleteCode(diskdb, h)
+
+		_, _, _, _, err := ExecuteStateless(config, vm.Config{}, newTask(), pb.witness, &pb.author, engine, diskdb)
+
+		rawdb.WriteCode(diskdb, h, code) // restore for the next iteration
+
+		switch {
+		case err == nil:
+			t.Fatalf("removing read code %x was silently tolerated (no error)", h)
+		case !errors.Is(err, ErrStatelessIncompleteState):
+			t.Fatalf("removing read code %x produced %v, want ErrStatelessIncompleteState", h, err)
+		case !strings.Contains(err.Error(), strings.TrimPrefix(h.Hex(), "0x")):
+			t.Fatalf("error for missing code %x does not name the hash: %v", h, err)
+		}
+
+		if tested++; testing.Short() && tested >= 1 {
+			break
+		}
+	}
+}

--- a/eth/downloader/bor_downloader.go
+++ b/eth/downloader/bor_downloader.go
@@ -18,6 +18,7 @@
 package downloader
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"math/big"
@@ -30,6 +31,7 @@ import (
 	"github.com/ethereum/go-ethereum/consensus/bor/heimdall/checkpoint"
 	"github.com/ethereum/go-ethereum/consensus/bor/heimdall/milestone"
 	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/state/snapshot"
 	"github.com/ethereum/go-ethereum/core/stateless"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -2390,13 +2392,65 @@ func (d *Downloader) importBlockResultsStateless(results []*fetchResult) error {
 	if d.chainInsertHook != nil {
 		d.chainInsertHook(results)
 	}
-	// Import the batch of blocks
-	if index, err := d.blockchain.InsertChainStateless(blocks, witnesses); err != nil {
+	// Import the batch of blocks. A stateless node reads contract code from
+	// local disk (WIT2 witnesses carry no code); if a witness-verified block
+	// referenced a contract whose bytecode was momentarily absent, the import
+	// fails with a recoverable *state.MissingCodeError. Fetch exactly that
+	// content-addressed blob from a peer, persist it, and retry — bounded so a
+	// blob no peer can serve degrades to the existing safe failure rather than
+	// looping. A batch may reference more than one missing code, each surfacing
+	// on a successive attempt.
+	index, err := d.blockchain.InsertChainStateless(blocks, witnesses)
+	for attempts := 0; err != nil && attempts < maxStatelessCodeHeals; attempts++ {
+		if !d.recoverMissingStatelessCode(err) {
+			break
+		}
+		index, err = d.blockchain.InsertChainStateless(blocks, witnesses)
+	}
+	if err != nil {
 		log.Warn("Stateless block import failed", "index", index, "hash", blocks[index].Hash(), "err", err)
 		return errInvalidBody
 	}
 
 	return nil
+}
+
+// maxStatelessCodeHeals bounds how many missing contract codes a single
+// stateless batch import will fetch-and-retry before giving up, so a blob no
+// peer can serve cannot spin the import forever.
+const maxStatelessCodeHeals = 8
+
+// statelessCodeHealTimeout bounds a single self-heal bytecode fetch.
+const statelessCodeHealTimeout = 30 * time.Second
+
+// recoverMissingStatelessCode attempts to self-heal a stateless import failure
+// caused by a contract whose bytecode is absent from local disk. If err carries
+// a *state.MissingCodeError, it fetches that content-addressed blob from a snap
+// peer, verifies it (FetchByteCodes checks the hash), and persists it to the
+// chain db so a retry can read it. It reports whether a retry is now warranted.
+// Any non-code failure, a missing SnapSyncer, or an unservable blob returns
+// false, leaving the caller's existing (safe) failure path intact.
+func (d *Downloader) recoverMissingStatelessCode(err error) bool {
+	var mce *state.MissingCodeError
+	if !errors.As(err, &mce) || d.SnapSyncer == nil {
+		return false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), statelessCodeHealTimeout)
+	defer cancel()
+
+	codes, ferr := d.SnapSyncer.FetchByteCodes(ctx, []common.Hash{mce.Hash})
+	if ferr != nil {
+		log.Warn("Stateless self-heal: bytecode fetch failed", "hash", mce.Hash, "err", ferr)
+		return false
+	}
+	code, ok := codes[mce.Hash]
+	if !ok {
+		log.Warn("Stateless self-heal: no peer served missing bytecode", "hash", mce.Hash)
+		return false
+	}
+	rawdb.WriteCode(d.stateDB, mce.Hash, code)
+	log.Info("Stateless self-heal: fetched and persisted missing contract code", "hash", mce.Hash, "size", len(code))
+	return true
 }
 
 // fetchWitnesses is a dedicated goroutine responsible for fetching block witnesses.

--- a/eth/downloader/stateless_selfheal_test.go
+++ b/eth/downloader/stateless_selfheal_test.go
@@ -1,0 +1,104 @@
+// Copyright 2024 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package downloader
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/eth/protocols/snap"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+// fakeCodePeer is a minimal snap.SyncPeer that answers bytecode requests from a
+// fixed corpus (well-behaving: request order, omitting hashes it lacks) and
+// no-ops every other request kind.
+type fakeCodePeer struct {
+	id     string
+	syncer *snap.Syncer
+	corpus map[common.Hash][]byte
+}
+
+func (p *fakeCodePeer) ID() string      { return p.id }
+func (p *fakeCodePeer) Log() log.Logger { return log.New("id", p.id) }
+
+func (p *fakeCodePeer) RequestAccountRange(id uint64, root, origin, limit common.Hash, bytes uint64) error {
+	return nil
+}
+
+func (p *fakeCodePeer) RequestStorageRanges(id uint64, root common.Hash, accounts []common.Hash, origin, limit []byte, bytes uint64) error {
+	return nil
+}
+
+func (p *fakeCodePeer) RequestTrieNodes(id uint64, root common.Hash, paths []snap.TrieNodePathSet, bytes uint64) error {
+	return nil
+}
+
+func (p *fakeCodePeer) RequestByteCodes(id uint64, hashes []common.Hash, bytes uint64) error {
+	var out [][]byte
+	for _, h := range hashes {
+		if code, ok := p.corpus[h]; ok {
+			out = append(out, code)
+		}
+	}
+	go p.syncer.OnByteCodes(p, id, out)
+	return nil
+}
+
+// TestRecoverMissingStatelessCode exercises the downloader self-heal hook:
+// a *state.MissingCodeError is healed by fetching the blob from a snap peer and
+// persisting it to the chain db; any other failure, or an unservable blob, is
+// left untouched for the caller's safe failure path.
+func TestRecoverMissingStatelessCode(t *testing.T) {
+	code := []byte{0x60, 0x2a, 0x60, 0x00, 0x52, 0x60, 0x20, 0x60, 0x00, 0xf3}
+	hash := crypto.Keccak256Hash(code)
+
+	chaindb := rawdb.NewMemoryDatabase()
+	syncer := snap.NewSyncer(rawdb.NewMemoryDatabase(), rawdb.HashScheme)
+	peer := &fakeCodePeer{id: "p1", syncer: syncer, corpus: map[common.Hash][]byte{hash: code}}
+	if err := syncer.Register(peer); err != nil {
+		t.Fatalf("register peer: %v", err)
+	}
+	d := &Downloader{stateDB: chaindb, SnapSyncer: syncer}
+
+	// A non-code failure must not be treated as recoverable, and must write nothing.
+	if d.recoverMissingStatelessCode(errors.New("gas limit reached")) {
+		t.Fatal("recovered a non-MissingCodeError")
+	}
+
+	// A missing code a peer can serve is fetched, verified and persisted.
+	if !d.recoverMissingStatelessCode(&state.MissingCodeError{Hash: hash}) {
+		t.Fatal("did not recover a servable missing code")
+	}
+	if got := rawdb.ReadCode(chaindb, hash); !bytes.Equal(got, code) {
+		t.Fatalf("healed code not persisted to chain db: got %x want %x", got, code)
+	}
+
+	// A missing code no peer serves is not recoverable (caller falls back to safe stop).
+	unservable := crypto.Keccak256Hash([]byte("no peer has this"))
+	if d.recoverMissingStatelessCode(&state.MissingCodeError{Hash: unservable}) {
+		t.Fatal("reported recovery for an unservable code")
+	}
+	if rawdb.HasCode(chaindb, unservable) {
+		t.Fatal("unservable code was somehow persisted")
+	}
+}

--- a/eth/protocols/snap/ondemand.go
+++ b/eth/protocols/snap/ondemand.go
@@ -1,0 +1,178 @@
+// Copyright 2024 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package snap
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+// onDemandReqidBit marks a request id as belonging to an out-of-band, targeted
+// bytecode fetch (FetchByteCodes) rather than the bulk sync loop. Loop reqids
+// are uint64(rand.Int63()) and so always have the top bit clear; setting it
+// guarantees the two id spaces never collide, so OnByteCodes can route a
+// response to the right place unambiguously.
+const onDemandReqidBit = uint64(1) << 63
+
+// onDemandCodeFetchTimeout bounds how long a single peer is given to answer a
+// targeted bytecode request before the next peer is tried.
+const onDemandCodeFetchTimeout = 15 * time.Second
+
+// onDemandCodeReq tracks one in-flight targeted bytecode request.
+type onDemandCodeReq struct {
+	deliver chan [][]byte
+}
+
+// FetchByteCodes retrieves the given contract bytecodes from a connected snap
+// peer on demand — outside the bulk sync state machine — verifying each blob
+// against its hash before returning it. It backs the stateless self-heal path:
+// when witness-verified execution references a contract whose code is absent
+// from local disk (WIT2 witnesses carry no code), the node fetches exactly that
+// content-addressed blob and re-persists it, instead of stalling.
+//
+// It returns the subset of hashes it could fetch and verify, keyed by hash; a
+// missing entry means no connected peer served it. Peers are tried in turn
+// until every hash is found, the peer set is exhausted, or ctx is cancelled.
+// Peers are registered by lifecycle (Register/Unregister) independently of a
+// running Sync cycle, so this works while the syncer is otherwise idle.
+func (s *Syncer) FetchByteCodes(ctx context.Context, hashes []common.Hash) (map[common.Hash][]byte, error) {
+	out := make(map[common.Hash][]byte, len(hashes))
+	if len(hashes) == 0 {
+		return out, nil
+	}
+	tried := make(map[string]struct{})
+	for {
+		// Reduce to the hashes still outstanding.
+		var pending []common.Hash
+		for _, h := range hashes {
+			if _, ok := out[h]; !ok {
+				pending = append(pending, h)
+			}
+		}
+		if len(pending) == 0 {
+			return out, nil
+		}
+		if len(pending) > maxCodeRequestCount {
+			pending = pending[:maxCodeRequestCount]
+		}
+
+		// Pick a peer we have not tried yet and that has not already declined to
+		// serve state.
+		s.lock.Lock()
+		var peer SyncPeer
+		for id, p := range s.peers {
+			if _, done := tried[id]; done {
+				continue
+			}
+			if _, bad := s.statelessPeers[id]; bad {
+				continue
+			}
+			peer, tried[id] = p, struct{}{}
+			break
+		}
+		if peer == nil {
+			s.lock.Unlock()
+			if len(out) > 0 {
+				return out, nil
+			}
+			return out, fmt.Errorf("snap: no peer available to serve %d bytecode(s) on demand", len(pending))
+		}
+		reqid := uint64(rand.Int63()) | onDemandReqidBit
+		req := &onDemandCodeReq{deliver: make(chan [][]byte, 1)}
+		s.onDemandCodeReqs[reqid] = req
+		s.lock.Unlock()
+
+		if err := peer.RequestByteCodes(reqid, pending, maxRequestSize); err != nil {
+			s.forgetOnDemandCodeReq(reqid)
+			log.Debug("On-demand bytecode request failed to send", "peer", peer.ID(), "err", err)
+			continue
+		}
+
+		select {
+		case codes := <-req.deliver:
+			s.forgetOnDemandCodeReq(reqid)
+			verifyAndCollectByteCodes(pending, codes, out)
+		case <-time.After(onDemandCodeFetchTimeout):
+			s.forgetOnDemandCodeReq(reqid)
+			log.Debug("On-demand bytecode request timed out", "peer", peer.ID(), "hashes", len(pending))
+		case <-ctx.Done():
+			s.forgetOnDemandCodeReq(reqid)
+			if len(out) > 0 {
+				return out, nil
+			}
+			return out, ctx.Err()
+		}
+	}
+}
+
+// onDemandByteCodes delivers a targeted bytecode response (top-bit reqid) to its
+// waiting FetchByteCodes caller. Stale, duplicate or unrequested responses are
+// dropped harmlessly.
+func (s *Syncer) onDemandByteCodes(id uint64, bytecodes [][]byte) error {
+	s.lock.Lock()
+	req, ok := s.onDemandCodeReqs[id]
+	if ok {
+		delete(s.onDemandCodeReqs, id)
+	}
+	s.lock.Unlock()
+	if !ok {
+		return nil
+	}
+	select {
+	case req.deliver <- bytecodes:
+	default:
+	}
+	return nil
+}
+
+func (s *Syncer) forgetOnDemandCodeReq(reqid uint64) {
+	s.lock.Lock()
+	delete(s.onDemandCodeReqs, reqid)
+	s.lock.Unlock()
+}
+
+// verifyAndCollectByteCodes hashes each delivered blob and, for any that matches
+// a still-wanted hash, records it into out. Unmatched or corrupt blobs are
+// ignored — a peer that returns garbage simply does not count as having served
+// that hash, and the caller moves on to the next peer. Because entry is keyed by
+// the verified keccak of the blob, a peer cannot inject code for the wrong hash.
+func verifyAndCollectByteCodes(wanted []common.Hash, delivered [][]byte, out map[common.Hash][]byte) {
+	hasher := crypto.NewKeccakState()
+	var h common.Hash
+	for _, blob := range delivered {
+		if len(blob) == 0 {
+			continue
+		}
+		hasher.Reset()
+		hasher.Write(blob)
+		hasher.Read(h[:])
+		for _, w := range wanted {
+			if h == w {
+				if _, ok := out[w]; !ok {
+					out[w] = blob
+				}
+				break
+			}
+		}
+	}
+}

--- a/eth/protocols/snap/ondemand_test.go
+++ b/eth/protocols/snap/ondemand_test.go
@@ -1,0 +1,113 @@
+// Copyright 2024 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package snap
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+// serveCodesFromCorpus returns a codeRequestHandler that answers with the
+// requested blobs it has in corpus, in request order, omitting any it lacks —
+// the well-behaving snap-server behaviour.
+func serveCodesFromCorpus(corpus map[common.Hash][]byte) codeHandlerFunc {
+	return func(tp *testPeer, id uint64, hashes []common.Hash, _ uint64) error {
+		var out [][]byte
+		for _, h := range hashes {
+			if code, ok := corpus[h]; ok {
+				out = append(out, code)
+			}
+		}
+		return tp.remote.OnByteCodes(tp, id, out)
+	}
+}
+
+func TestFetchByteCodesOnDemand(t *testing.T) {
+	codeA := []byte{0x60, 0x00, 0x60, 0x00, 0xf3}
+	codeB := []byte{0xfe, 0x00, 0x01}
+	hashA := crypto.Keccak256Hash(codeA)
+	hashB := crypto.Keccak256Hash(codeB)
+	unknown := crypto.Keccak256Hash([]byte("no peer has this"))
+
+	syncer := NewSyncer(rawdb.NewMemoryDatabase(), rawdb.HashScheme)
+	peer := newTestPeer("server", t, func() { t.Helper(); t.Fatal("peer terminated") })
+	peer.remote = syncer
+	peer.codeRequestHandler = serveCodesFromCorpus(map[common.Hash][]byte{hashA: codeA, hashB: codeB})
+	if err := syncer.Register(peer); err != nil {
+		t.Fatalf("register peer: %v", err)
+	}
+
+	// Both present → both returned and byte-exact.
+	got, err := syncer.FetchByteCodes(context.Background(), []common.Hash{hashA, hashB})
+	if err != nil {
+		t.Fatalf("FetchByteCodes: %v", err)
+	}
+	if !bytes.Equal(got[hashA], codeA) || !bytes.Equal(got[hashB], codeB) {
+		t.Fatalf("wrong codes: got[A]=%x got[B]=%x", got[hashA], got[hashB])
+	}
+
+	// A hash no peer serves must not appear in the result (and must not be
+	// fabricated).
+	got, _ = syncer.FetchByteCodes(context.Background(), []common.Hash{unknown})
+	if _, ok := got[unknown]; ok {
+		t.Fatalf("unknown hash was served a value: %x", got[unknown])
+	}
+}
+
+// TestFetchByteCodesFailsOverAndVerifies proves the fetch rejects a peer that
+// returns bytes not matching the requested hash (content-addressed check) and
+// fails over to a peer that serves the correct blob.
+func TestFetchByteCodesFailsOverAndVerifies(t *testing.T) {
+	code := []byte{0x60, 0x2a, 0x60, 0x00, 0x52, 0x60, 0x20, 0x60, 0x00, 0xf3}
+	hash := crypto.Keccak256Hash(code)
+
+	syncer := NewSyncer(rawdb.NewMemoryDatabase(), rawdb.HashScheme)
+
+	liar := newTestPeer("liar", t, func() {})
+	liar.remote = syncer
+	liar.codeRequestHandler = func(tp *testPeer, id uint64, hashes []common.Hash, _ uint64) error {
+		// Serve the wrong bytes for every requested hash.
+		out := make([][]byte, len(hashes))
+		for i := range out {
+			out[i] = []byte{0xde, 0xad, 0xbe, 0xef}
+		}
+		return tp.remote.OnByteCodes(tp, id, out)
+	}
+	honest := newTestPeer("honest", t, func() {})
+	honest.remote = syncer
+	honest.codeRequestHandler = serveCodesFromCorpus(map[common.Hash][]byte{hash: code})
+
+	if err := syncer.Register(liar); err != nil {
+		t.Fatalf("register liar: %v", err)
+	}
+	if err := syncer.Register(honest); err != nil {
+		t.Fatalf("register honest: %v", err)
+	}
+
+	got, err := syncer.FetchByteCodes(context.Background(), []common.Hash{hash})
+	if err != nil {
+		t.Fatalf("FetchByteCodes: %v", err)
+	}
+	if !bytes.Equal(got[hash], code) {
+		t.Fatalf("failover did not yield the verified code: got %x want %x", got[hash], code)
+	}
+}

--- a/eth/protocols/snap/sync.go
+++ b/eth/protocols/snap/sync.go
@@ -466,6 +466,11 @@ type Syncer struct {
 	bytecodeReqs map[uint64]*bytecodeRequest // Bytecode requests currently running
 	storageReqs  map[uint64]*storageRequest  // Storage requests currently running
 
+	// Out-of-band targeted bytecode fetches issued outside the bulk sync loop
+	// (see FetchByteCodes / ondemand.go). Keyed by a reqid with the top bit set
+	// so it can never collide with loop reqids (uint64(rand.Int63())).
+	onDemandCodeReqs map[uint64]*onDemandCodeReq
+
 	accountSynced  uint64             // Number of accounts downloaded
 	accountBytes   common.StorageSize // Number of account trie bytes persisted to disk
 	bytecodeSynced uint64             // Number of bytecodes downloaded
@@ -532,6 +537,8 @@ func NewSyncer(db ethdb.KeyValueStore, scheme string) *Syncer {
 		accountReqs:  make(map[uint64]*accountRequest),
 		storageReqs:  make(map[uint64]*storageRequest),
 		bytecodeReqs: make(map[uint64]*bytecodeRequest),
+
+		onDemandCodeReqs: make(map[uint64]*onDemandCodeReq),
 
 		trienodeHealIdlers: make(map[string]struct{}),
 		bytecodeHealIdlers: make(map[string]struct{}),
@@ -2791,6 +2798,12 @@ func (s *Syncer) OnAccounts(peer SyncPeer, id uint64, hashes []common.Hash, acco
 // OnByteCodes is a callback method to invoke when a batch of contract
 // bytes codes are received from a remote peer.
 func (s *Syncer) OnByteCodes(peer SyncPeer, id uint64, bytecodes [][]byte) error {
+	// Targeted, out-of-band fetches (FetchByteCodes) use a top-bit reqid and are
+	// delivered to their waiting caller, not the bulk sync scheduler.
+	if id&onDemandReqidBit != 0 {
+		return s.onDemandByteCodes(id, bytecodes)
+	}
+
 	s.lock.RLock()
 	syncing := !s.snapped
 	s.lock.RUnlock()


### PR DESCRIPTION
> **Stacked on #2401** — base branch is `lmartins/stateless-incomplete-state-guard`,
> not `develop`. Review/merge #2401 first; the diff here is only the three
> commits on top of it. It builds directly on the typed error #2401 introduces.

## Problem

#2401 makes a stateless node **detect** a missing contract code and reject the
block instead of masking it. But rejection alone means the node stalls on that
block until the code happens to arrive by some other path. A WIT2 witness never
carries code, so there is no in-band way to recover — the node needs to fetch
exactly the missing blob.

## Fix

Three layers, bottom-up:

1. **`core/state`** — `MissingCodeError{Addr, Hash}` types the two "code is not
   found" paths in `stateObject.Code`/`CodeSize` (message unchanged, so
   witness-regen fixtures still match) and is wrapped into `ExecuteStateless`'s
   result. A caller can now `errors.As` the missing hash, and tell a missing
   **code** (fetchable, content-addressed) from a missing **trie node** (an
   incomplete witness, not fetchable).

2. **`eth/protocols/snap`** — `Syncer.FetchByteCodes` fetches specific bytecodes
   from a connected snap peer *outside* the bulk sync loop, verifying each blob
   against its hash and failing over across peers. Responses route by a top-bit
   reqid (loop reqids are `uint64(rand.Int63())`, top bit clear, so the id
   spaces never collide). Peers are usable because `Register`/`Unregister` track
   them independently of a running `Sync` cycle — the stateless case, where the
   initial heal has already completed.

3. **`eth/downloader`** — on a `*state.MissingCodeError` from a stateless batch
   import, fetch that content-addressed blob, persist it to the chain db, and
   retry the batch. Bounded by `maxStatelessCodeHeals` so a blob no peer can
   serve degrades to the existing safe failure instead of looping; a batch
   referencing several missing codes heals them across successive attempts. Any
   non-code failure is left to the caller's existing path untouched.

## Test

- `core/state` — the guard test (#2401) is extended to assert the hash
  round-trips via `errors.As`.
- `eth/protocols/snap` — `TestFetchByteCodesOnDemand` (well-behaving peer;
  unknown hash never fabricated) and `TestFetchByteCodesFailsOverAndVerifies`
  (fails over past a peer returning bytes that don't match the requested hash).
- `eth/downloader` — `TestRecoverMissingStatelessCode` (a servable miss is
  fetched, verified and persisted; a non-code error and an unservable blob are
  both left for the safe failure path, writing nothing).

## Scope / risk

Every fetched blob is verified content-addressed (`keccak(code) == hash`) before
it is persisted, so a malicious peer cannot inject wrong code — it simply fails
over. Recovery is bounded and safe-stops on an unservable code. Together with
#2401 this recovers **any** missing code at execution time regardless of how the
gap arose (heal incompleteness, crash window, or fast-forward), which is why it
is deployed ahead of any mechanism-specific prevention.
